### PR TITLE
AsyncGraphEdgeParams trait for easier AsyncGraph modularisation.

### DIFF
--- a/src/async_graph/impl_async_graph.rs
+++ b/src/async_graph/impl_async_graph.rs
@@ -1,68 +1,51 @@
-use crate::async_graph::AsyncGraph;
-use crate::bdd_params::{build_static_constraints, BddParameterEncoder, BddParams};
-use crate::{BooleanNetwork, VariableId};
-use biodivine_lib_std::param_graph::Params;
-use biodivine_lib_std::IdState;
+use crate::async_graph::{AsyncGraph, AsyncGraphEdgeParams, DefaultEdgeParams};
+use crate::BooleanNetwork;
 
-impl AsyncGraph {
-    /// Create a new `AsyncGraph` from the given `BooleanNetwork`.
-    pub fn new(network: BooleanNetwork) -> Result<AsyncGraph, String> {
+impl AsyncGraph<DefaultEdgeParams> {
+    /// Create a new `AsyncGraph` from the given `BooleanNetwork` using default edge parameter implementation.
+    pub fn new(network: BooleanNetwork) -> Result<AsyncGraph<DefaultEdgeParams>, String> {
         return if network.graph.num_vars() > 32 {
             Err("Can't create the graph. At most 32 variables supported".to_string())
         } else {
-            let encoder = BddParameterEncoder::new(&network);
-            let unit_set = BddParams::from(build_static_constraints(&network, &encoder));
-            if unit_set.is_empty() {
-                Err("No update functions satisfy given constraints".to_string())
-            } else {
-                Ok(AsyncGraph {
-                    network,
-                    encoder,
-                    unit_set,
-                })
-            }
+            let edge_params = DefaultEdgeParams::new(network)?;
+            return Ok(AsyncGraph { edges: edge_params });
+        };
+    }
+}
+
+impl<Params: AsyncGraphEdgeParams> AsyncGraph<Params> {
+    /// Create a new `AsyncGraph` using given edge parametrisation.
+    pub fn new_with_edges(edge_params: Params) -> Result<AsyncGraph<Params>, String> {
+        return if edge_params.network().graph.num_vars() > 32 {
+            Err("Can't create the graph. At most 32 variables supported".to_string())
+        } else {
+            return Ok(AsyncGraph { edges: edge_params });
         };
     }
 
     /// Return the total number of states in this graph.
     pub fn num_states(&self) -> usize {
-        return 1 << self.network.graph.num_vars();
+        return 1 << self.network().graph.num_vars();
     }
 
-    /// Return an empty parameter set.
-    pub fn empty_params(&self) -> BddParams {
-        return BddParams::from(self.encoder.bdd_variables.mk_false());
+    /// Return a reference to the original Boolean network.
+    pub fn network(&self) -> &BooleanNetwork {
+        return self.edges.network();
     }
 
-    /// Return a unit parameter set, i.e. all parameters that satisfy all static conditions.
-    pub fn unit_params(&self) -> &BddParams {
-        return &self.unit_set;
+    /// Make a witness network for one parametrisation in the given set.
+    pub fn make_witness(&self, params: &Params::ParamSet) -> BooleanNetwork {
+        return self.edges.make_witness(params);
     }
 
-    /// Compute the parameter set which enables the value of `variable` to be flipped
-    /// in the given `state`.
-    ///
-    /// Note that this set is not a subset of the `unit_set`! It is really just the flip condition.
-    pub fn edge_params(&self, state: IdState, variable: VariableId) -> BddParams {
-        // First, compute the parameter set that sends value of variable to true in this state
-        let update_function = &self.network.update_functions[variable.0];
-        let edge_params = if let Some(update_function) = update_function {
-            update_function.symbolic_eval_true(state, &self.encoder)
-        } else {
-            let var = self.encoder.get_implicit(state, variable);
-            BddParams::from(self.encoder.bdd_variables.mk_var(var))
-        };
-
-        // Now if we actually want to go to false, invert the set:
-        return if state.get_bit(variable.0) {
-            BddParams::from(edge_params.into_bdd().not())
-        } else {
-            edge_params
-        };
+    /// Return an empty set of parameters.
+    pub fn empty_params(&self) -> &Params::ParamSet {
+        return self.edges.empty_params();
     }
 
-    pub fn make_witness(&self, params: &BddParams) -> BooleanNetwork {
-        return self.network.make_witness(params, &self.encoder);
+    /// Return a full set of parameters.
+    pub fn unit_params(&self) -> &Params::ParamSet {
+        return self.edges.unit_params();
     }
 }
 
@@ -85,7 +68,7 @@ mod tests {
         .unwrap();
         let graph = AsyncGraph::new(network).unwrap();
         // both functions can have 3 different valuations, so 9 in total
-        assert_eq!(9.0, graph.unit_set.cardinality());
+        assert_eq!(9.0, graph.unit_params().cardinality());
     }
 
     #[test]
@@ -105,6 +88,6 @@ mod tests {
         // p can have 2 valuations, q can have 4, 8 in total
         // actually, for b, there is only one possible function but it is achieved
         // regardless of two values of q.
-        assert_eq!(8.0, graph.unit_set.cardinality());
+        assert_eq!(8.0, graph.unit_params().cardinality());
     }
 }

--- a/src/async_graph/impl_default_edge_params.rs
+++ b/src/async_graph/impl_default_edge_params.rs
@@ -1,0 +1,65 @@
+use crate::async_graph::{AsyncGraphEdgeParams, DefaultEdgeParams};
+use crate::bdd_params::{build_static_constraints, BddParameterEncoder, BddParams};
+use crate::{BooleanNetwork, VariableId};
+use biodivine_lib_std::param_graph::Params;
+use biodivine_lib_std::IdState;
+
+impl DefaultEdgeParams {
+    /// New default edge parametrisation for the given network. Warning: computes the unit set, which can be expensive.
+    pub fn new(network: BooleanNetwork) -> Result<DefaultEdgeParams, String> {
+        let encoder = BddParameterEncoder::new(&network);
+        let unit_set = BddParams::from(build_static_constraints(&network, &encoder));
+        if unit_set.is_empty() {
+            Err("No update functions satisfy given constraints".to_string())
+        } else {
+            Ok(DefaultEdgeParams {
+                empty_set: BddParams::from(encoder.bdd_variables.mk_false()),
+                network,
+                encoder,
+                unit_set,
+            })
+        }
+    }
+}
+
+impl AsyncGraphEdgeParams for DefaultEdgeParams {
+    type ParamSet = BddParams;
+
+    fn network(&self) -> &BooleanNetwork {
+        return &self.network;
+    }
+
+    fn empty_params(&self) -> &Self::ParamSet {
+        return &self.empty_set;
+    }
+
+    fn unit_params(&self) -> &Self::ParamSet {
+        return &self.unit_set;
+    }
+
+    /// Compute the parameter set which enables the value of `variable` to be flipped
+    /// in the given `state`.
+    ///
+    /// Note that this set is not a subset of the `unit_set`! It is really just the flip condition.
+    fn edge_params(&self, state: IdState, variable: VariableId) -> BddParams {
+        // First, compute the parameter set that sends value of variable to true in this state
+        let update_function = &self.network.update_functions[variable.0];
+        let edge_params = if let Some(update_function) = update_function {
+            update_function.symbolic_eval_true(state, &self.encoder)
+        } else {
+            let var = self.encoder.get_implicit(state, variable);
+            BddParams::from(self.encoder.bdd_variables.mk_var(var))
+        };
+
+        // Now if we actually want to go to false, invert the set:
+        return if state.get_bit(variable.0) {
+            BddParams::from(edge_params.into_bdd().not())
+        } else {
+            edge_params
+        };
+    }
+
+    fn make_witness(&self, params: &Self::ParamSet) -> BooleanNetwork {
+        return self.network.make_witness(params, &self.encoder);
+    }
+}

--- a/src/async_graph/mod.rs
+++ b/src/async_graph/mod.rs
@@ -1,50 +1,92 @@
 use crate::bdd_params::{BddParameterEncoder, BddParams};
-use crate::{BooleanNetwork, VariableIdIterator};
+use crate::{BooleanNetwork, VariableId, VariableIdIterator};
 use biodivine_lib_std::param_graph::{Graph, InvertibleGraph};
 use biodivine_lib_std::{IdState, IdStateRange};
 
 mod impl_async_graph;
+mod impl_default_edge_params;
 mod impl_evolution_operators;
 
 /// An asynchronous transition system of a `BooleanNetwork`. The states of the graph
-/// are standard `IdState`s. The parameter sets of the graph are the `BddParams`.
-pub struct AsyncGraph {
+/// are standard `IdState`s. The parameter sets are given by the associated `AsyncGraphEdgeParams`.
+///
+/// Async graph implements the standard "asynchronous update", i.e. every variable can be
+/// non-deterministically updated at any time, but the actual parameters for which this
+/// happens are determined by the `AsyncGraphEdgeParams`.
+///
+/// This actually hides a lot of complexity, because implementing `AsyncGraphEdgeParams` is typically
+/// much easier than re-implementing the whole async graph structure.
+pub struct AsyncGraph<P: AsyncGraphEdgeParams> {
+    edges: P,
+}
+
+/// Default implementation for edge parameters which adheres to the monotonicity and observability
+/// constraints  of the network, but poses no other restrictions.
+pub struct DefaultEdgeParams {
     network: BooleanNetwork,
     encoder: BddParameterEncoder,
     /// The parameter valuations which satisfy the static regulation constraints.
     unit_set: BddParams,
+    empty_set: BddParams,
+}
+
+/// Async graph edges implement the edge colouring (parametrisation) of a graph. Instances of
+/// this trait are used together with the `AsyncGraph` to produce a semantic coloured graph
+/// of a parametrised Boolean network.
+///
+/// See `DefaultEdgeParams` for default implementation of edge colours.
+///
+/// This trait is especially useful when constructing things like wrappers of existing graphs,
+/// which need to modify the behaviour of the graph. Another option are various custom
+/// parameter encoders, where we simply do not want to re-implement the whole graph trait
+/// front scratch.
+pub trait AsyncGraphEdgeParams {
+    type ParamSet: biodivine_lib_std::param_graph::Params;
+    // A reference to the underlying Boolean network.
+    fn network(&self) -> &BooleanNetwork;
+    /// Create a new empty set of parameters.
+    fn empty_params(&self) -> &Self::ParamSet;
+    /// Create a new full set of parameters.
+    fn unit_params(&self) -> &Self::ParamSet;
+    /// Create parameters for the edge starting in the given `state`,
+    /// flipping the given `variable`.
+    fn edge_params(&self, state: IdState, variable: VariableId) -> Self::ParamSet;
+    /// Construct a witness network for the given set of parameters.
+    ///
+    /// TODO: It is not really essential in this trait. Think of a way to move it elsewhere.
+    fn make_witness(&self, params: &Self::ParamSet) -> BooleanNetwork;
 }
 
 /// A forward `EvolutionOperator` of the `AsyncGraph`.
-pub struct Fwd<'a> {
-    graph: &'a AsyncGraph,
+pub struct Fwd<'a, Edges: AsyncGraphEdgeParams> {
+    graph: &'a AsyncGraph<Edges>,
 }
 
 /// A backward `EvolutionOperator` of the `AsyncGraph`.
-pub struct Bwd<'a> {
-    graph: &'a AsyncGraph,
+pub struct Bwd<'a, Edges: AsyncGraphEdgeParams> {
+    graph: &'a AsyncGraph<Edges>,
 }
 
 /// An iterator over successors of a state in the `AsyncGraph`.
-pub struct FwdIterator<'a> {
-    graph: &'a AsyncGraph,
+pub struct FwdIterator<'a, Edges: AsyncGraphEdgeParams> {
+    graph: &'a AsyncGraph<Edges>,
     state: IdState,
     variables: VariableIdIterator,
 }
 
 /// An iterator over predecessors of a state in the `AsyncGraph`.
-pub struct BwdIterator<'a> {
-    graph: &'a AsyncGraph,
+pub struct BwdIterator<'a, Edges: AsyncGraphEdgeParams> {
+    graph: &'a AsyncGraph<Edges>,
     state: IdState,
     variables: VariableIdIterator,
 }
 
-impl<'a> Graph for &'a AsyncGraph {
+impl<'a, Edges: AsyncGraphEdgeParams> Graph for &'a AsyncGraph<Edges> {
     type State = IdState;
-    type Params = BddParams;
+    type Params = Edges::ParamSet;
     type States = IdStateRange;
-    type FwdEdges = Fwd<'a>;
-    type BwdEdges = Bwd<'a>;
+    type FwdEdges = Fwd<'a, Edges>;
+    type BwdEdges = Bwd<'a, Edges>;
 
     fn states(&self) -> Self::States {
         return IdStateRange::new(self.num_states());
@@ -59,7 +101,7 @@ impl<'a> Graph for &'a AsyncGraph {
     }
 }
 
-impl<'a> InvertibleGraph for &'a AsyncGraph {
-    type FwdEdges = Fwd<'a>;
-    type BwdEdges = Bwd<'a>;
+impl<'a, Edges: AsyncGraphEdgeParams> InvertibleGraph for &'a AsyncGraph<Edges> {
+    type FwdEdges = Fwd<'a, Edges>;
+    type BwdEdges = Bwd<'a, Edges>;
 }

--- a/src/impl_variable_id.rs
+++ b/src/impl_variable_id.rs
@@ -1,5 +1,5 @@
 use crate::VariableId;
-use std::fmt::{Display, Formatter, Error};
+use std::fmt::{Display, Error, Formatter};
 
 impl From<usize> for VariableId {
     fn from(val: usize) -> Self {


### PR DESCRIPTION
Introduces `AsyncGraphEdgeParams` as a component of the `AsyncGraph`. Now, the responsibility of creating a coloured (parametrised) graph is split into two:

The `AsyncGraph` generates the state space and possible edges (possible non-deterministic updates), implementing the `Graph` and `InvertibleGraph` traits. It then calls the `AsyncGraphEdgeParams` which determines the colours (parametrisations) of the actual edge. 

This architecture is beneficial, because it allows tweaking the graph structure without unnecessarily re-implementing the explicit state space of the non-deterministic graph. It even allows for nested (delegated) implementations of `AsyncGraphEdgeParams` where the `DefaultEdgeParams` are used as a basis for further filtering or restriction of the graph.

Note that this does not meaningfully change any existing public API of the crate (it  add a reference to the signature of `AsyncGraph::empty_params` to match `AsyncGraph::unit_params`), but it adds a few new methods (aside from `AsyncGraphEdgeParams` and `DefaultEdgeParams` obviously).