### PR TITLE
Add binary to dump explicit colored graphs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 authors = ["Samuel Pastva <daemontus@gmail.com>"]
 edition = "2018"
 
+[lib]
+name = "biodivine_lib_param_bn"
+path = "src/lib.rs"
+
+[[bin]]
+name = "dump-graph"
+path = "src/bin/dump_graph.rs"
+
 # Enable rich docs for some online docs autogen services.
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "docs-head.html"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# biodivine-lib-param-bn
-Rust library for working with parametrised Boolean networks.
+# Biodivine Parametrised Boolean Networks
+Rust library for working with parametrised Boolean networks. Work in progress.
+
+## PBN to colour graph dump
+
+To analyse (very) small networks, it can be useful to 
+dump them as explicit coloured graphs. There is a binary for that.
+
+First, run `cargo build --release`.
+
+You can then find the binary in `target/release/dump-graph`. 
+The binary takes `.aeon` model on standard input and dumps
+the graph to standard output. So to convert a PBN to its 
+coloured asynchronous transition
+graph, simply call `dump-graph < ~/path/to/model.aeon > graph_file.txt`.
+
+Since the graph is explicit, expect the output size to be unmanageable
+for PBNs with roughly >10 variables and >1000 valid parametrisations 
+(with parametrisations being the bigger problem).
+
+You can test the functionality on `aeon_models/g2a_*.aeon` models which
+should all be sufficiently small.   

--- a/aeon_models/g2a_instantiated.aeon
+++ b/aeon_models/g2a_instantiated.aeon
@@ -1,0 +1,25 @@
+#position:CtrA:111.66352760384814,126.42721496242696
+$CtrA:((((!CtrA & GcrA) & !CcrM) & !SciP) | ((CtrA & !CcrM) & !SciP))
+CtrA -> CtrA
+GcrA -> CtrA
+CcrM -| CtrA
+SciP -| CtrA
+#position:GcrA:100.3490877216902,240.07968457434436
+$GcrA:(!CtrA & DnaA)
+CtrA -| GcrA
+DnaA -> GcrA
+#position:CcrM:19.5,36.69417762322472
+$CcrM:((CtrA & !CcrM) & !SciP)
+CtrA -> CcrM
+CcrM -| CcrM
+SciP -| CcrM
+#position:SciP:112.86364349451134,24.5
+$SciP:(CtrA & !DnaA)
+CtrA -> SciP
+DnaA -| SciP
+#position:DnaA:20.80798906179652,148.90428148236617
+$DnaA:(((CtrA & !GcrA) & !DnaA) & CcrM)
+CtrA -> DnaA
+GcrA -| DnaA
+DnaA -| DnaA
+CcrM -> DnaA

--- a/aeon_models/g2a_p1026.aeon
+++ b/aeon_models/g2a_p1026.aeon
@@ -1,0 +1,23 @@
+#position:CtrA:111.66352760384814,126.42721496242696
+CtrA -> CtrA
+GcrA -> CtrA
+CcrM -| CtrA
+SciP -| CtrA
+#position:GcrA:100.3490877216902,240.07968457434436
+$GcrA:(!CtrA & DnaA)
+CtrA -| GcrA
+DnaA -> GcrA
+#position:CcrM:19.5,36.69417762322472
+CtrA -> CcrM
+CcrM -| CcrM
+SciP -| CcrM
+#position:SciP:112.86364349451134,24.5
+$SciP:(CtrA & !DnaA)
+CtrA -> SciP
+DnaA -| SciP
+#position:DnaA:20.80798906179652,148.90428148236617
+$DnaA:(((CtrA & !GcrA) & !DnaA) & CcrM)
+CtrA -> DnaA
+GcrA -| DnaA
+DnaA -| DnaA
+CcrM -> DnaA

--- a/aeon_models/g2a_p9.aeon
+++ b/aeon_models/g2a_p9.aeon
@@ -1,0 +1,24 @@
+#position:CtrA:111.66352760384814,126.42721496242696
+$CtrA:((((!CtrA & GcrA) & !CcrM) & !SciP) | ((CtrA & !CcrM) & !SciP))
+CtrA -> CtrA
+GcrA -> CtrA
+CcrM -| CtrA
+SciP -| CtrA
+#position:GcrA:100.3490877216902,240.07968457434436
+$GcrA:(!CtrA & DnaA)
+CtrA -| GcrA
+DnaA -> GcrA
+#position:CcrM:19.5,36.69417762322472
+CtrA -> CcrM
+CcrM -| CcrM
+SciP -| CcrM
+#position:SciP:112.86364349451134,24.5
+$SciP:(CtrA & !DnaA)
+CtrA -> SciP
+DnaA -| SciP
+#position:DnaA:20.80798906179652,148.90428148236617
+$DnaA:(((CtrA & !GcrA) & !DnaA) & CcrM)
+CtrA -> DnaA
+GcrA -| DnaA
+DnaA -| DnaA
+CcrM -> DnaA

--- a/src/bin/dump_graph.rs
+++ b/src/bin/dump_graph.rs
@@ -1,0 +1,52 @@
+use biodivine_lib_bdd::{BddValuation, BddValuationIterator};
+use biodivine_lib_param_bn::async_graph::AsyncGraph;
+use biodivine_lib_param_bn::bdd_params::BddParameterEncoder;
+use biodivine_lib_param_bn::BooleanNetwork;
+use biodivine_lib_std::param_graph::{EvolutionOperator, Graph};
+use std::convert::TryFrom;
+use std::io::Read;
+
+/// Dump aeon model from stdin as explicit coloured graph to stdout.
+/// Provides extra debug info on stderr...
+fn main() {
+    let mut buffer = String::new();
+    std::io::stdin().read_to_string(&mut buffer).unwrap();
+
+    let model = BooleanNetwork::try_from(buffer.as_str()).unwrap();
+
+    let ref encoder = BddParameterEncoder::new(&model);
+    let ref graph = AsyncGraph::new(model).unwrap();
+    let all_colors = graph.unit_params().clone().into_bdd();
+
+    // Compute all actually valid valuations
+    eprintln!("Graph loaded...");
+    eprintln!("Vertices: {}", graph.num_states());
+    eprintln!("Colors: {}", all_colors.cardinality());
+    let p_num_vars = encoder.bdd_variables.num_vars();
+    let valid_valuations: Vec<BddValuation> = BddValuationIterator::new(p_num_vars)
+        .filter(|v| all_colors.eval_in(v))
+        .collect();
+
+    let fwd = graph.fwd();
+    for s in graph.states() {
+        for (t, p) in fwd.step(s) {
+            let s: usize = s.into();
+            let t: usize = t.into();
+            let p = p.into_bdd();
+            if !p.is_false() {
+                println!("{} -> {}", s, t);
+                let mut first = true;
+                for i in 0..valid_valuations.len() {
+                    if p.eval_in(&valid_valuations[i]) {
+                        if !first {
+                            print!("|");
+                        }
+                        print!("{}", i);
+                        first = false;
+                    }
+                }
+                println!();
+            }
+        }
+    }
+}


### PR DESCRIPTION
For some small experiments, it is useful to have a binary that explicitly prints the semantic graph of the PBN. 

This PR: 
 - Adds `dump_graph.rs` binary which prints the graph as simple text.
 - Adds some small `.aeon` models which the user can verify the functionality on.
 - Adds explanation to README how to use the `dump-graph` binary.