### PR TITLE
Further bugfixes to SBML parsing.

### DIFF
--- a/.githooks/README.txt
+++ b/.githooks/README.txt
@@ -1,0 +1,3 @@
+To globally enable githooks, run:
+
+git config core.hooksPath .githooks

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Runs automatic formatting and tests
+
+exec cargo fmt -- --check
+exec cargo build --all-features
+exec cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ rustdoc-args = ["--html-in-header", "docs-head.html"]
 
 [dependencies]
 regex = "1.3.3"     # used when parsing text format
-xml-rs = "0.8.0"    # facilitates sbml parsing
+#xml-rs = "0.8.0"    # facilitates sbml parsing
+# There is a bug in xml-rs which prevents parsing of strings that contain />.
+# Until https://github.com/netvl/xml-rs/pull/195 is merged and released, we
+# have to use this for which actually fixes it.
+xml-rs = { git="https://github.com/jdalberg/xml-rs.git", branch="parsefix" }
 biodivine-lib-bdd = { git = "https://github.com/sybila/biodivine-lib-bdd.git" }
 biodivine-lib-std = { git = "https://github.com/sybila/biodivine-lib-std.git" }
 

--- a/sbml_models/apoptosis_network.sbml
+++ b/sbml_models/apoptosis_network.sbml
@@ -1,0 +1,2961 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" qual:required="true" version="1" xmlns:qual="http://www.sbml.org/sbml/level3/version1/qual/version1">
+  <model id="M2329" metaid="b8fb31f4-3e5e-4668-abdb-774e1e5fe6d2" name="Apoptosis Network">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">To understand the design principles of the molecular interaction network associated with the irreversibility of cell apoptosis and the stability of cell surviving, we constructed a Boolean network integrating both the intrinsic and extrinsic pro-apoptotic pathways with pro-survival signal transduction pathways. We performed statistical analyses of the dependences of cell fate on initial states and on input signals. The analyses reproduced the well-known pro- and anti-apoptotic effects of key external signals and network components. We found that the external GF signal by itself did not change the apoptotic ratio from randomly chosen initial states when there is no external TNF signal, but can significantly offset apoptosis induced by the TNF signal. While a complete model produces the expected irreversibility of the apoptosis process, alternative models missing one or more of four selected inter-component connections indicate that the feedback loops directly involving the caspase 3 are essential for maintaining irreversibility of apoptosis. The feedback loops involving P53 showed compensating effects when those involving caspase 3 have been removed. The GF signal significantly increases the stability of the surviving states of the network. The apoptosis network seems to use different modules by design to control the irreversibility of the apoptosis process and the stability of the surviving states. Such a design may accommodate the needed plasticity for the network to adapt to different cellular environments: depending on the strength of external pro-surviving signals, apoptosis can be induced either easily or difficultly by pro-apoptotic signal of varying strengths, but proceed with invariable irreversibility.</body>
+    </notes>
+    <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#b8fb31f4-3e5e-4668-abdb-774e1e5fe6d2">
+	<dc:creator>
+	<rdf:Bag>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Helikar</vCard:Family>
+	<vCard:Given>Tomas</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>thelika@unmc.edu</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>University of Nebraska - Lincoln</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	</rdf:Bag>
+	</dc:creator>
+	<dcterms:created rdf:parseType="Resource">
+	<dcterms:W3CDTF>2014-02-01T14:41:22Z</dcterms:W3CDTF>
+	</dcterms:created>
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T16:16:10Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+      <qual:listOfQualitativeSpecies xmlns:qual="http://www.sbml.org/sbml/level3/version1/qual/version1">
+      <qual:qualitativeSpecies metaid="fe2cade3-27df-47dc-8494-8b8d77840f6d" qual:compartment="extracellular" qual:constant="true" qual:id="S_25" qual:name="GF">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/">
+	<rdf:Description rdf:about="#fe2cade3-27df-47dc-8494-8b8d77840f6d">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="b105307d-f277-49c9-8ea0-f3406b5507f6" qual:compartment="extracellular" qual:constant="true" qual:id="S_29" qual:name="TNF">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/">
+	<rdf:Description rdf:about="#b105307d-f277-49c9-8ea0-f3406b5507f6">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_33ff1b4f-1d9a-4607-bc76-90aad6c7c0d7" qual:compartment="cytosol" qual:constant="false" qual:id="S_1" qual:initialLevel="0" qual:maxLevel="1" qual:name="PIP3">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;span style="border: 0px; outline: 0px; line-height: 17px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">&lt;span style="line-height: 17px;">&lt;font face="Georgia" size="2">Phosphatidylinositol Triphosphate&lt;/font>&lt;/span>&lt;/span>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="border: 0px; outline: 0px; line-height: 17px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">&lt;span style="line-height: 17px;">PubChem ID:&lt;/span>&lt;/span>&lt;span style="line-height: 19px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;a name="cid2entrez" href="http://www.ncbi.nlm.nih.gov/sites/entrez?cmd=search&amp;amp;db=pccompound&amp;amp;term=53480352[uid]" style="border: 0px; outline: 0px; line-height: 19px; vertical-align: baseline; margin: 0px; padding: 0px; text-decoration: none; background-color: rgb(255, 255, 255);">53480352&lt;br/>&lt;/a>&lt;span style="border: 0px; outline: 0px; line-height: 17px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">Molecular Formula:&lt;/span>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">&amp;nbsp;C&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">47&lt;/sub>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">H&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">86&lt;/sub>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">O&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">22&lt;/sub>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">P&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">4&lt;/sub>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;/span>&lt;span style="border: 0px; outline: 0px; line-height: 17px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">Molecular Weight:&lt;/span>&lt;span style="line-height: 17px; background-color: rgb(255, 255, 255);">&amp;nbsp;1127.067588&amp;nbsp;&lt;/span>&lt;/font>&lt;/div>&lt;div style="font-weight: normal; font-size: 10pt; font-family: Arial, Verdana;">&lt;span style="color: rgb(85, 85, 85); font-family: Arial, Verdana, sans-serif; font-size: 13px; line-height: 17px; background-color: rgb(255, 255, 255);">&lt;br/>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_33ff1b4f-1d9a-4607-bc76-90aad6c7c0d7">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15784165"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16545436"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16274701"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="d0f57b03-6f56-476c-a15a-b0f4a2b03a5e" qual:compartment="cytosol" qual:constant="false" qual:id="S_2" qual:initialLevel="0" qual:maxLevel="1" qual:name="GFR">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Represents "growth family receptors" in the Apoptosis Network [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#d0f57b03-6f56-476c-a15a-b0f4a2b03a5e">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_13055bd7-1a94-47c6-aa2d-5cf68e76e630" qual:compartment="cytosol" qual:constant="false" qual:id="S_3" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas7">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">7&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">, apoptosis-related cysteine peptidase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P55210" style="text-decoration: none; background-color: rgb(255, 255, 255);">P55210&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/840" ref="ordinalpos=1&amp;amp;ncbi_uid=840&amp;amp;link_uid=840" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP7&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">840&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_13055bd7-1a94-47c6-aa2d-5cf68e76e630">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15601572"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12110144"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_60a6e717-7951-435c-b818-8d712f6ca4ac" qual:compartment="cytosol" qual:constant="false" qual:id="S_4" qual:initialLevel="0" qual:maxLevel="1" qual:name="PTEN">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Phosphatase&lt;/span>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;and&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">tensin&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 18.88888931274414px;">&lt;/span>&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">homolog&lt;/span>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;[&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P60484" style="text-decoration: none; background-color: rgb(255, 255, 255);">P60484&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/5728" ref="ordinalpos=1&amp;amp;ncbi_uid=5728&amp;amp;link_uid=5728" style="line-height: 18.88888931274414px; white-space: nowrap; background-color: rgb(255, 255, 255);">PTEN&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">5728&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_60a6e717-7951-435c-b818-8d712f6ca4ac">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16545436"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16274701"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_817bc0a6-7f24-4af0-8e47-b605e5d25b9c" qual:compartment="cytosol" qual:constant="false" qual:id="S_5" qual:initialLevel="0" qual:maxLevel="1" qual:name="TNFR2">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Tumor necrosis factor receptor superfamily, member 1B [&lt;/span>&lt;em style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P20333" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">P20333&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/7133" ref="ordinalpos=3&amp;amp;ncbi_uid=7133&amp;amp;link_uid=7133" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">TNFRSF1B&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">7133&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_817bc0a6-7f24-4af0-8e47-b605e5d25b9c">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T14:29:29Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_42751991-6a41-48ed-b4fb-f73f96010957" qual:compartment="cytosol" qual:constant="false" qual:id="S_6" qual:initialLevel="0" qual:maxLevel="1" qual:name="PIP2">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Phosphatidylinositol-4,5-biphosphate&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="border: 0px; outline: 0px; line-height: 17.445960998535156px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">Molecular Formula:&lt;/span>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">&amp;nbsp;C&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">9&lt;/sub>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">H&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">21&lt;/sub>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">O&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">17&lt;/sub>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">P&lt;/span>&lt;sub style="border: 0px; outline: 0px; line-height: 0; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">3&lt;/sub>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;/span>&lt;span style="border: 0px; outline: 0px; line-height: 17.445960998535156px; vertical-align: baseline; margin: 0px; padding: 0px; background-color: rgb(255, 255, 255);">Molecular Weight:&lt;/span>&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">&amp;nbsp;494.174126&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 17.445960998535156px; background-color: rgb(255, 255, 255);">PubChem ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 19.384401321411133px;">&lt;a href="http://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?cid=125105">125105&lt;/a>&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_42751991-6a41-48ed-b4fb-f73f96010957">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15784165"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="de7ad265-9590-4b8b-a2e6-fa05e7224610" qual:compartment="cytosol" qual:constant="false" qual:id="S_7" qual:initialLevel="0" qual:maxLevel="1" qual:name="Apaf1">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Apoptotic peptidase activating factor 1 [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;/div>&lt;font face="Georgia" size="2">Uniprot ID:&amp;nbsp;&lt;a href="http://www.uniprot.org/uniprot/O14727" style="text-decoration: none; background-color: rgb(255, 255, 255);">O14727&lt;/a>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">Gene Name:&amp;nbsp;&lt;a href="http://www.ncbi.nlm.nih.gov/gene/317" ref="ordinalpos=1&amp;amp;ncbi_uid=317&amp;amp;link_uid=317" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">APAF1&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">NCBI Gene ID:&amp;nbsp;&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">317&lt;/span&gt;&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#de7ad265-9590-4b8b-a2e6-fa05e7224610">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15908180"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15865941"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12972501"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_0619b466-0de6-48a8-b717-21d46fab688f" qual:compartment="cytosol" qual:constant="false" qual:id="S_8" qual:initialLevel="0" qual:maxLevel="1" qual:name="TRAF2">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">TNF receptor-associated factor 2 [&lt;/span>&lt;em style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;span class="highlight">Homo&lt;/span>&amp;nbsp;sapiens&lt;/em>&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q12933" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">Q12933&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/7186" ref="ordinalpos=1&amp;amp;ncbi_uid=7186&amp;amp;link_uid=7186" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">TRAF2&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">7186&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_0619b466-0de6-48a8-b717-21d46fab688f">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T14:29:29Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_08e846e9-4b27-4819-acea-f639a9f22a48" qual:compartment="cytosol" qual:constant="false" qual:id="S_9" qual:initialLevel="0" qual:maxLevel="1" qual:name="TRAF">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">TNF receptor-associated factor 1 [&lt;/span>&lt;em style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;span class="highlight">Homo&lt;/span>&amp;nbsp;sapiens&lt;/em>&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q13077" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">Q13077&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/7185" ref="ordinalpos=1&amp;amp;ncbi_uid=7185&amp;amp;link_uid=7185" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">TRAF1&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">7185&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_08e846e9-4b27-4819-acea-f639a9f22a48">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-07-19T10:59:00Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_48766ca2-049f-477f-934f-38564819e601" qual:compartment="cytosol" qual:constant="false" qual:id="S_10" qual:initialLevel="0" qual:maxLevel="1" qual:name="TNFR1">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="line-height: 19.999780654907227px; font-size: 13.333333969116211px; background-color: rgb(255, 255, 255);">Tumor necrosis factor receptor superfamily, member 1A [&lt;/span>&lt;em style="line-height: 19.999780654907227px; font-size: 13.333333969116211px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; font-size: 13.333333969116211px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div style="line-height: normal;">&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P19438" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">P19438&lt;/a>&lt;/font>&lt;/div>&lt;div style="line-height: normal;">&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/7132" ref="ordinalpos=2&amp;amp;ncbi_uid=7132&amp;amp;link_uid=7132" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">TNFRSF1A&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">7132&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_48766ca2-049f-477f-934f-38564819e601">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_2b61de0a-58b7-41b3-a96c-3eac8baef242" qual:compartment="cytosol" qual:constant="false" qual:id="S_11" qual:initialLevel="0" qual:maxLevel="1" qual:name="MEKK1">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">Mitogen-activated protein kinase kinase kinase 1, E3 ubiquitin protein ligase&lt;/font>&lt;/span>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q13233" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q13233&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/4214" ref="ordinalpos=4&amp;amp;ncbi_uid=4214&amp;amp;link_uid=4214" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">MAP3K1&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">4214&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_2b61de0a-58b7-41b3-a96c-3eac8baef242">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T16:16:10Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="dc1e00ec-79ab-4f1e-a0ff-0d6d2c78ce49" qual:compartment="cytosol" qual:constant="false" qual:id="S_12" qual:initialLevel="0" qual:maxLevel="1" qual:name="IKK">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Inhibitor of kappa light polypeptide gene enhancer in B-cells, kinase beta [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/O14920" style="text-decoration: none; background-color: rgb(255, 255, 255);">O14920&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/3551" ref="ordinalpos=6&amp;amp;ncbi_uid=3551&amp;amp;link_uid=3551" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">IKBKB&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">NCBI Gene ID: 3551&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#dc1e00ec-79ab-4f1e-a0ff-0d6d2c78ce49">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_6c27f8f2-6db0-4e7a-b6d1-8c9372450768" qual:compartment="cytosol" qual:constant="false" qual:id="S_13" qual:initialLevel="0" qual:maxLevel="1" qual:name="TRADD">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">TNFRSF1A-associated via death domain [&lt;/span>&lt;em style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;br/>&lt;/font>&lt;div>&lt;font face="Georgia">&lt;font size="2">UniProt Accession ID:&amp;nbsp;&lt;/font>&lt;a href="http://www.uniprot.org/uniprot/Q15628" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">Q15628&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">Gene Name:&amp;nbsp;&lt;a href="http://www.ncbi.nlm.nih.gov/gene/8717" ref="ordinalpos=1&amp;amp;ncbi_uid=8717&amp;amp;link_uid=8717" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">TRADD&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">NCBI Gene ID:&amp;nbsp;&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">8717&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_6c27f8f2-6db0-4e7a-b6d1-8c9372450768">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_0db1f998-09b1-4cb1-96dd-a32b90b21ba2" qual:compartment="cytosol" qual:constant="false" qual:id="S_14" qual:initialLevel="0" qual:maxLevel="1" qual:name="cFLIP">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">CASP8 and FADD-like apoptosis regulator [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/O15519" style="text-decoration: none; background-color: rgb(255, 255, 255);">O15519&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/8837" ref="ordinalpos=2&amp;amp;ncbi_uid=8837&amp;amp;link_uid=8837" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CFLAR&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">8837&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_0db1f998-09b1-4cb1-96dd-a32b90b21ba2">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_9edaa999-dee8-442e-9f1d-0debca8e8cd9" qual:compartment="cytosol" qual:constant="false" qual:id="S_15" qual:initialLevel="0" qual:maxLevel="1" qual:name="Mito">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Represents the release of apoptotic signals from the mitochondria [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_9edaa999-dee8-442e-9f1d-0debca8e8cd9">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15908180"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15865941"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12972501"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="c4c011f9-a306-4f39-8683-6e5ace14ccd5" qual:compartment="cytosol" qual:constant="false" qual:id="S_16" qual:initialLevel="0" qual:maxLevel="1" qual:name="IkB">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;font face="Georgia" size="2">Represents the inhibitor of nuclear factor kappa-B.&amp;nbsp;&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 16px; background-color: rgb(255, 255, 255);">Inhibitor of nuclear factor kappa-B kinase subunit beta&amp;nbsp;&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 16px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255);">O14920&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/4793" ref="ordinalpos=7&amp;amp;ncbi_uid=4793&amp;amp;link_uid=4793" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">NFKBIB&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">NCBI Gene ID:&amp;nbsp;&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">4793&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">&lt;font face="Georgia" size="2">&lt;br/>&lt;/font>&lt;/span>&lt;/div>&lt;div style="font-size: 10pt; font-family: Arial, Verdana;">&lt;span style="font-size: 16px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia">&lt;br/>&lt;/font>&lt;/span>&lt;/div>&lt;div style="font-size: 10pt; font-family: Arial, Verdana; font-weight: normal;">&lt;strong style="font-family: sans-serif; font-size: 16px; background-color: rgb(255, 255, 255);">&lt;br/>&lt;/strong>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#c4c011f9-a306-4f39-8683-6e5ace14ccd5">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:51:06Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9299557"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9516122"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15485624"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15861135"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:8943045"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="ce4c5810-79d4-4820-abd5-31dba3bb1de2" qual:compartment="cytosol" qual:constant="false" qual:id="S_17" qual:initialLevel="0" qual:maxLevel="1" qual:name="RIP">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Receptor (TNFRSF)-interacting serine-threonine kinase 1 [&lt;/span>&lt;em style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;span class="highlight">Homo&lt;/span>&amp;nbsp;sapiens&lt;/em>&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q13546" style="font-size: small; text-decoration: none; background-color: rgb(255, 255, 255);">Q13546&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/8737" ref="ordinalpos=1&amp;amp;ncbi_uid=8737&amp;amp;link_uid=8737" style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">RIPK1&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="font-size: 13.333333969116211px; line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); font-size: 12.222222328186035px; line-height: 17.999801635742188px;">8737&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#ce4c5810-79d4-4820-abd5-31dba3bb1de2">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T16:16:10Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_0becd8b2-de2d-47a0-8335-8213054aa6eb" qual:compartment="cytosol" qual:constant="false" qual:id="S_18" qual:initialLevel="0" qual:maxLevel="1" qual:name="JNK">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Mitogen-activated protein kinase 8 [&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P45983" style="text-decoration: none; background-color: rgb(255, 255, 255);">P45983&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/5599" ref="ordinalpos=5&amp;amp;ncbi_uid=5599&amp;amp;link_uid=5599" style="line-height: 18.88888931274414px; white-space: nowrap; background-color: rgb(255, 255, 255);">MAPK8&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">5599&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_0becd8b2-de2d-47a0-8335-8213054aa6eb">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_2c9de631-eb1f-4e41-a46b-58f81b6a9b4e" qual:compartment="cytosol" qual:constant="false" qual:id="S_19" qual:initialLevel="0" qual:maxLevel="1" qual:name="NIK">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2" style="background-color: rgb(255, 255, 255);">&lt;span style="line-height: 18.88888931274414px;">Mitogen-activated protein kinase kinase kinase 14 [&lt;/span>&lt;em style="line-height: 18.88888931274414px;">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px;">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2" style="background-color: rgb(255, 255, 255);">&lt;span style="line-height: 18.88888931274414px;">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q99558" style="text-decoration: none;">Q99558&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2" style="background-color: rgb(255, 255, 255);">&lt;span style="line-height: 18.88888931274414px;">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/9020" ref="ordinalpos=3&amp;amp;ncbi_uid=9020&amp;amp;link_uid=9020" style="line-height: 18.88888931274414px; white-space: nowrap;">MAP3K14&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2" style="background-color: rgb(255, 255, 255);">&lt;span style="line-height: 18.88888931274414px;">Gene ID:&lt;/span>&lt;span style="line-height: 17.77777862548828px;">9020&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_2c9de631-eb1f-4e41-a46b-58f81b6a9b4e">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="e0baa15f-e98a-4138-a4d6-a718c4b18296" qual:compartment="cytosol" qual:constant="false" qual:id="S_20" qual:initialLevel="0" qual:maxLevel="1" qual:name="DNADamageEvent">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Represents damage to DNA [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#e0baa15f-e98a-4138-a4d6-a718c4b18296">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:24:03Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_97d81999-5a3b-4c17-ac07-a054c863b98d" qual:compartment="cytosol" qual:constant="false" qual:id="S_21" qual:initialLevel="0" qual:maxLevel="1" qual:name="JNKK">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Mitogen-activated protein kinase kinase 4 [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P45985" style="text-decoration: none; background-color: rgb(255, 255, 255);">P45985&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/6416" ref="ordinalpos=2&amp;amp;ncbi_uid=6416&amp;amp;link_uid=6416" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">MAP2K4&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">NCBI Gene ID: 6416&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_97d81999-5a3b-4c17-ac07-a054c863b98d">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="fbd65198-2d2a-4de4-8e51-e8db55b1f583" qual:compartment="cytosol" qual:constant="false" qual:id="S_22" qual:initialLevel="0" qual:maxLevel="1" qual:name="NFkB">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font size="2" face="Georgia">Referring&amp;nbsp;to p65(RelA):p50\r\nheterodimers in this context [1].&amp;nbsp;&lt;/font>&lt;div style="font-style: normal; font-variant: normal; font-weight: normal; line-height: normal;">&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Nuclear&lt;/span>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">factor&lt;/span>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;of kappa light polypeptide gene enhancer in B-cells 1 [&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P19838" style="text-decoration: none; background-color: rgb(255, 255, 255);">P19838&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/4790" ref="ordinalpos=6&amp;amp;ncbi_uid=4790&amp;amp;link_uid=4790" style="line-height: 18.88888931274414px; white-space: nowrap; background-color: rgb(255, 255, 255);">NFKB1&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene ID:&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">4790&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">v-rel avian reticuloendotheliosis viral oncogene homolog A [&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q04206" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q04206&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/5970" ref="ordinalpos=1&amp;amp;ncbi_uid=5970&amp;amp;link_uid=5970" style="line-height: 18.88888931274414px; white-space: nowrap; background-color: rgb(255, 255, 255);">RELA&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene ID:&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">5970&lt;/span>&lt;/font>&lt;/div>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#fbd65198-2d2a-4de4-8e51-e8db55b1f583">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:51:06Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9299557"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9516122"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_320bcdf5-b343-408d-a361-eb5d65100b0e" qual:compartment="cytosol" qual:constant="false" qual:id="S_23" qual:initialLevel="0" qual:maxLevel="1" qual:name="AKT">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;br/></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_320bcdf5-b343-408d-a361-eb5d65100b0e">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15784165"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_581e427d-29cc-4c17-a349-1e19c750c82f" qual:compartment="cytosol" qual:constant="false" qual:id="S_24" qual:initialLevel="0" qual:maxLevel="1" qual:name="BclX">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">BCL2-like 1 [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q07817" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q07817&lt;/a>&lt;span style="background-color: rgb(255, 255, 255); line-height: 19.999780654907227px;">&amp;nbsp;&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/598" ref="ordinalpos=2&amp;amp;ncbi_uid=598&amp;amp;link_uid=598" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">BCL2L1&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">598&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_581e427d-29cc-4c17-a349-1e19c750c82f">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:51:06Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16751281"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9990849"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_8daf2454-c584-4b95-a65f-7717de40a151" qual:compartment="cytosol" qual:constant="false" qual:id="S_26" qual:initialLevel="0" qual:maxLevel="1" qual:name="A20">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="line-height: 16px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia">AN1-type zinc finger protein 5&lt;/font>&lt;/span>&lt;div>&lt;font face="Georgia">&lt;span style="line-height: 16px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255);">O76080&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;span style="background-color: rgb(255, 255, 255);">&lt;font face="Georgia">&lt;br/>&lt;/font>&lt;/span>&lt;/div>&lt;div>&lt;font face="Georgia">&lt;span style="background-color: rgb(255, 255, 255);">alternative names:&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 16px;">Zinc finger A20 domain-containing protein 2&lt;/span>&lt;/font>&lt;/div>&lt;div style="font-size: 10pt; font-family: Arial, Verdana;">&lt;br/>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_8daf2454-c584-4b95-a65f-7717de40a151">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9299557"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9516122"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="bf19abed-e24a-4045-a72f-3f6e4b3beb46" qual:compartment="cytosol" qual:constant="false" qual:id="S_27" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas3">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">3&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">, apoptosis-related cysteine peptidase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P42574" style="text-decoration: none; background-color: rgb(255, 255, 255);">P42574&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/836" ref="ordinalpos=2&amp;amp;ncbi_uid=836&amp;amp;link_uid=836" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP3&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">836&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#bf19abed-e24a-4045-a72f-3f6e4b3beb46">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:5601572"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12110144"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="cdd878da-293d-4b26-a4d3-add8d7edf0ca" qual:compartment="cytosol" qual:constant="false" qual:id="S_28" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas8">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;8, apoptosis-related cysteine peptidase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q14790" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q14790&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/841" ref="ordinalpos=2&amp;amp;ncbi_uid=841&amp;amp;link_uid=841" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP8&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">NCBI Gene ID: 841&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#cdd878da-293d-4b26-a4d3-add8d7edf0ca">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:11464214"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15861135"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15601572"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15485624"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:8943045"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12110144"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_8ebbb8b8-7f40-4771-a028-c3dec06ae86a" qual:compartment="cytosol" qual:constant="false" qual:id="S_30" qual:initialLevel="0" qual:maxLevel="1" qual:name="Apoptosis">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>programmed cell death</p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_8ebbb8b8-7f40-4771-a028-c3dec06ae86a">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:24:03Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="b1bd8f1d-56fe-4739-aa2f-2ea547996576" qual:compartment="cytosol" qual:constant="false" qual:id="S_31" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas6">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">6&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">, apoptosis-related cysteine peptidase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div style="line-height: normal;">&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P55212" style="text-decoration: none; background-color: rgb(255, 255, 255);">P55212&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/839" ref="ordinalpos=2&amp;amp;ncbi_uid=839&amp;amp;link_uid=839" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP6&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCABI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">839&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#b1bd8f1d-56fe-4739-aa2f-2ea547996576">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_9a83f5ba-911d-4f80-92d2-55b93930be17" qual:compartment="cytosol" qual:constant="false" qual:id="S_32" qual:initialLevel="0" qual:maxLevel="1" qual:name="p53">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Tumor protein&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">p53&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">[&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P04637" style="text-decoration: none; background-color: rgb(255, 255, 255);">P04637&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/7157" ref="ordinalpos=2&amp;amp;ncbi_uid=7157&amp;amp;link_uid=7157" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">TP53&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">7157&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_9a83f5ba-911d-4f80-92d2-55b93930be17">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10958661"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15865941"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12972501"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9529147"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15908180"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="fc4874b2-e2f3-41b8-959a-c52bf0ce2900" qual:compartment="cytosol" qual:constant="false" qual:id="S_33" qual:initialLevel="0" qual:maxLevel="1" qual:name="PI3K">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Phosphatidylinositol&lt;/span>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">-4,5-bisphosphate 3-kinase, catalytic subunit alpha [&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P42336" style="text-decoration: none; background-color: rgb(255, 255, 255);">P42336&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/5290" ref="ordinalpos=1&amp;amp;ncbi_uid=5290&amp;amp;link_uid=5290" style="background-color: rgb(255, 255, 255); line-height: 18.88888931274414px; white-space: nowrap;">PIK3CA&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.77777862548828px;">5290&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#fc4874b2-e2f3-41b8-959a-c52bf0ce2900">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15784165"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="b5ca110b-69c9-47a0-b318-ea32e68c023e" qual:compartment="cytosol" qual:constant="false" qual:id="S_34" qual:initialLevel="0" qual:maxLevel="1" qual:name="BAD">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">BCL2-associated agonist of cell death [&lt;/span>&lt;em style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q92934" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q92934&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/572" ref="ordinalpos=1&amp;amp;ncbi_uid=572&amp;amp;link_uid=572" style="line-height: 18.88888931274414px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">BAD&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 18.88888931274414px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">Gene ID: 572&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#b5ca110b-69c9-47a0-b318-ea32e68c023e">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10365962"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_2285afa7-bfd0-4eee-ba94-6994ba5cefa2" qual:compartment="cytosol" qual:constant="false" qual:id="S_35" qual:initialLevel="0" qual:maxLevel="1" qual:name="APC">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2" style="font-style: normal; font-variant: normal; font-weight: normal; line-height: normal;">This node represents the&amp;nbsp;apoptosome complex [1]. Information about the apoptosome at (&lt;/font>&lt;font face="Georgia" size="2">&lt;a href="http://www.ncbi.nlm.nih.gov/mesh/?term=apoptosome">http://www.ncbi.nlm.nih.gov/mesh/?term=apoptosome&lt;/a>).&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_2285afa7-bfd0-4eee-ba94-6994ba5cefa2">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="e771e705-7cab-44fd-ba64-c0a653d15397" qual:compartment="cytosol" qual:constant="false" qual:id="S_36" qual:initialLevel="0" qual:maxLevel="1" qual:name="Mdm2">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">MDM2&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;oncogene, E3 ubiquitin protein ligase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q00987" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q00987&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/4193" ref="ordinalpos=1&amp;amp;ncbi_uid=4193&amp;amp;link_uid=4193" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">MDM2&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">NCBI Gene ID: 4193&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#e771e705-7cab-44fd-ba64-c0a653d15397">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_5475ec0a-b8db-4279-99a9-6ec6889faec5" qual:compartment="cytosol" qual:constant="false" qual:id="S_37" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas12">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">12&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(gene/pseudogene) [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/Q6UXS9" style="text-decoration: none; background-color: rgb(255, 255, 255);">Q6UXS9&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/100506742" ref="ordinalpos=5&amp;amp;ncbi_uid=100506742&amp;amp;link_uid=100506742" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP12&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">NCBI Gene ID:&amp;nbsp;&lt;/span>&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">100506742&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_5475ec0a-b8db-4279-99a9-6ec6889faec5">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_72ceffa0-0bdd-48d5-a387-eff07ad4eca8" qual:compartment="cytosol" qual:constant="false" qual:id="S_38" qual:initialLevel="0" qual:maxLevel="1" qual:name="IAP">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font size="2" style="font-style: normal;" face="Georgia">baculoviral IAP repeat-containing 2 (BIRC2)&lt;/font>&lt;div style="font-style: normal;">&lt;font face="Georgia">&lt;font size="2">UniProt Accession ID: Q13490&lt;/font>&lt;font size="2">&lt;br/>&lt;/font>&lt;/font>&lt;div>&lt;font size="2" face="Georgia">&lt;br/>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">baculoviral IAP repeat-containing 3 (BIRC3)&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">UniProt Accession ID: Q13489&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;br/>&lt;/font&gt;&lt;/div>&lt;div>&lt;font face="Georgia" size="2">baculoviral IAP repeat-containing 4 (BIRC4)&lt;/font>&lt;/div>&lt;/div>&lt;div style="font-style: normal;">&lt;font face="Georgia" size="2">UniProt Accession ID: P98170&lt;/font>&lt;/div>&lt;div style="font-style: normal;">&lt;font face="Georgia" size="2">&lt;br/>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">In the &lt;em>Apoptosis Network&lt;/em>, IAP represents inhibitors of apoptosis [1].&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;br/>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">In Survival Signaling 2008 and 2011, IAP represents inhibitors of apoptosis.&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_72ceffa0-0bdd-48d5-a387-eff07ad4eca8">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:51:06Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:9990849"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:16751281"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="eae4db7c-2cc2-4de3-a5ed-72bf9f50ade3" qual:compartment="cytosol" qual:constant="false" qual:id="S_39" qual:initialLevel="0" qual:maxLevel="1" qual:name="Cas9">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Caspase&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;&lt;/span>&lt;span class="highlight" style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">9&lt;/span>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">, apoptosis-related cysteine peptidase [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">UniProt ID:&amp;nbsp;&lt;/span>&lt;a href="http://www.uniprot.org/uniprot/P55211" style="text-decoration: none; background-color: rgb(255, 255, 255);">P55211&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Gene Name:&amp;nbsp;&lt;/span>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/842" ref="ordinalpos=1&amp;amp;ncbi_uid=842&amp;amp;link_uid=842" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">CASP9&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">NCBI Gene ID: 842&lt;/font>&lt;/span>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#eae4db7c-2cc2-4de3-a5ed-72bf9f50ade3">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-11-15T19:54:34Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15601572"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12110144"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_74904ea5-4eda-4e1a-81bc-4a38c82f7fcc" qual:compartment="cytosol" qual:constant="false" qual:id="S_40" qual:initialLevel="0" qual:maxLevel="1" qual:name="BID">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">BH3 interacting domain death agonist [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">&amp;nbsp;(human)]&lt;/span>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">UniProt Accession ID:&amp;nbsp;&lt;a href="http://www.uniprot.org/uniprot/P55957" style="text-decoration: none; background-color: rgb(255, 255, 255);">P55957&lt;br/>&lt;/a>&lt;font>Gene Name:&amp;nbsp;&lt;/font>&lt;a href="http://www.ncbi.nlm.nih.gov/gene/637" ref="ordinalpos=1&amp;amp;ncbi_uid=637&amp;amp;link_uid=637" style="color: rgb(100, 42, 143); line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">BID&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">Gene ID: 637&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_74904ea5-4eda-4e1a-81bc-4a38c82f7fcc">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:15865941"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:12110144"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+      <qual:qualitativeSpecies metaid="_0afd16f2-7132-454e-8dfd-7e96d6e25026" qual:compartment="cytosol" qual:constant="false" qual:id="S_41" qual:initialLevel="0" qual:maxLevel="1" qual:name="FADD">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;div>&lt;font face="Georgia" size="2">&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Fas (TNFRSF6)-associated via death domain [&lt;/span>&lt;em style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">Homo sapiens&lt;/em>&lt;span style="line-height: 19.999780654907227px; background-color: rgb(255, 255, 255);">(human)]&lt;/span>&lt;/font>&lt;/div>&lt;font face="Georgia" size="2">Uniprot ID:&amp;nbsp;Q13158&lt;/font>&lt;div>&lt;font face="Georgia" size="2">Gene Name:&amp;nbsp;&lt;a href="http://www.ncbi.nlm.nih.gov/gene/8772" ref="ordinalpos=1&amp;amp;ncbi_uid=8772&amp;amp;link_uid=8772" style="line-height: 19.999780654907227px; white-space: nowrap; background-color: rgb(255, 255, 255);">&lt;span class="highlight">FADD&lt;/span>&lt;/a>&lt;/font>&lt;/div>&lt;div>&lt;font face="Georgia" size="2">NCBI Gene ID:&amp;nbsp;&lt;span style="background-color: rgb(255, 255, 255); line-height: 17.999801635742188px;">8772&lt;/span>&lt;/font>&lt;/div></p></body>
+        </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#_0afd16f2-7132-454e-8dfd-7e96d6e25026">
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2017-10-13T15:42:38Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:10629108"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="urn:miriam:pubmed:19422837"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </qual:qualitativeSpecies>
+    </qual:listOfQualitativeSpecies>
+    <qual:listOfTransitions xmlns:qual="http://www.sbml.org/sbml/level3/version1/qual/version1">
+      <qual:transition qual:id="tr_S_1">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">PI3K and pip2 are both required to activate pip3. PTEN inhibits pip3 and is dominant over all activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_1_in_S_4" qual:qualitativeSpecies="S_4" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">PTEN dephosphorylates pip3 and thereby degrades it [1,3,4].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_1_in_S_33" qual:qualitativeSpecies="S_33" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">PI3K produces pip3 from pip2 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_1_in_S_6" qual:qualitativeSpecies="S_6" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">PI3K produces pip3 from pip2 [1,2].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_1" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_33 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <eq/>
+                    <ci> S_6 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_4 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_2">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">GF activates GFR [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_2_in_S_25" qual:qualitativeSpecies="S_25" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Growth factors activate growth factor receptors [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_2" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_25 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_3">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Caspase 7 is activated by APC or caspase 8. IAP is a negative regulator of caspase 7 and is dominant over both activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_3_in_S_38" qual:qualitativeSpecies="S_38" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">IAP is an inhibitor of caspase 7 [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_3_in_S_28" qual:qualitativeSpecies="S_28" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">Caspase 7 is activated by caspase 8 [1, 2, 3].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_3_in_S_35" qual:qualitativeSpecies="S_35" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Caspase 7 is activated by APC [1, 2, 3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_3" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_28 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_38 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_35 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_38 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_4">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia;">p53 activates PTEN [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_4_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">p53 activates PTEN [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_4" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_32 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_5">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia;">TNF activates TNFR2 [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_5_in_S_29" qual:qualitativeSpecies="S_29" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TNF activates TNFR2 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_5" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_29 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_6">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">GFR activates PIP2 [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_6_in_S_2" qual:qualitativeSpecies="S_2" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">GFR activates PIP2 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_6" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_2 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_7">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">p53 activates Apaf1 [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_7_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">The central regulator p53&amp;nbsp;generates pro-apoptotic output via Apaf1 [1,2,3,4].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_7" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_32 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_8">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">TNFR2 activates TRAF2 [1].&amp;nbsp;&lt;/font></p><p>RIP activates TRAF2.</p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_8_in_S_17" qual:qualitativeSpecies="S_17" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>Both RIP and TRAF2 are required for IKK activation.</p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_8_in_S_5" qual:qualitativeSpecies="S_5" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TNFR2 activates TRAF2 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_8" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <eq/>
+                  <ci> S_5 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <eq/>
+                  <ci> S_17 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_9">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia;">TRADD activates TRAF [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_9_in_S_13" qual:qualitativeSpecies="S_13" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TRADD activates TRAF [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_9" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_13 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_10">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">TNFR1 is activated by TNF [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_10_in_S_29" qual:qualitativeSpecies="S_29" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TNFR1 is activated by TNF [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_10" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_29 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_11">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">RIP activates Mekk1 [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_11_in_S_17" qual:qualitativeSpecies="S_17" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>RIP phosphorylates MEKK1 at Ser-957 and Ser-994.</p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_11" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_17 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_12">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">AKT and NIK each activate IKK, while A20 inhibits IKK and is dominant over both activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_12_in_S_23" qual:qualitativeSpecies="S_23" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">AKT activates IKK [1].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_12_in_S_19" qual:qualitativeSpecies="S_19" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">NIK activates IKK [1].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_12_in_S_26" qual:qualitativeSpecies="S_26" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">A20 inhibits IKK [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_12" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_19 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_26 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_23 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_26 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_13">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia;">TNFR1 activates TRADD [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_13_in_S_10" qual:qualitativeSpecies="S_10" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TNFR1 activates TRADD [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_13" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_10 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_14">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">TRAF activates cFLIP [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_14_in_S_9" qual:qualitativeSpecies="S_9" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">TRAF activates cFLIP [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_14" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_9 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_15">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">BID activates Mito, while BclX deactivates Mito and is dominant over BID [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_15_in_S_40" qual:qualitativeSpecies="S_40" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BID generates a pro-apoptotic signal [1,2,3,4].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_15_in_S_24" qual:qualitativeSpecies="S_24" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BclX prevents the release of apoptotic signals from the mitochondria [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_15" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_40 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_24 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_16">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">NFkB activates ikb and IKK deactivates ikb and is dominant over the effect of NFkB [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_16_in_S_12" qual:qualitativeSpecies="S_12" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">The activated IkB kinase complex (IKK) removes the inhibitor of NFkB (IKB) [1,4,5,6,7].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_16_in_S_22" qual:qualitativeSpecies="S_22" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">NfkB exerts negative feedback regulation on its own production by activating ikb [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_16" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_22 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_12 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_17">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia;">TRADD activates RIP [1].&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_17_in_S_13" qual:qualitativeSpecies="S_13" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">TRADD activates RIP [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_17" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_13 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_18">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">JNKK activates JNK [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_18_in_S_21" qual:qualitativeSpecies="S_21" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">JNKK activates JNK [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_18" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_21 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_19">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">TRAF2 activates NIK [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_19_in_S_8" qual:qualitativeSpecies="S_8" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">TRAF2 activates NIK [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_19" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_8 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_20">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Cas3 activates DNADamage [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_20_in_S_27" qual:qualitativeSpecies="S_27" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">DNA Damage Event is activated by Cas3 after two time units have occurred. According to Mai and Liu, "This node is\r\nalways set to the OFF state unless the caspase 3 node has been in\r\nthe ON state in previous two successive steps: only when both\r\nS&lt;sub>Cas3&lt;/sub>(t=1) = ON and S&lt;sub>Cas3&lt;/sub>(t) = ON, S&lt;sub>DNA Damage Event&lt;/sub>(t+1) = ON,\r\notherwise S&lt;sub>DNA Damage Event&lt;/sub>(t+1) = OFF [1]."</p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_20" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_27 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_21">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">MEKK1 activates JNKK, while AKT inhibits JNKK and is dominant over MEKK1 [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_21_in_S_23" qual:qualitativeSpecies="S_23" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">AKt inhibits JNKK [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_21_in_S_11" qual:qualitativeSpecies="S_11" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">MEKK1 activates JNKK [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_21" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_11 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_23 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_22">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">IkB inactivates NFkB [1].&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_22_in_S_16" qual:qualitativeSpecies="S_16" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">IkB inactivates NFkB [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_22" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <not/>
+                <apply>
+                  <eq/>
+                  <ci> S_16 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_23">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">PIP3 activates Akt [1, 2].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_23_in_S_1" qual:qualitativeSpecies="S_1" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>\r\n		\r\n	\r\n	\r\n		&lt;div class="page" title="Page 2">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2">PIP3 activates Akt [1,2].&amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_23" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_1 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_24">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">NFkB activates BclX, while both BAD and p53 are inhibitor s of BclX and are dominant over NfkB [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_24_in_S_22" qual:qualitativeSpecies="S_22" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">NFkB activates BclX [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_24_in_S_34" qual:qualitativeSpecies="S_34" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BAD creates pro-apoptotic effects by inhibiting BclX [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_24_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">p53 inhibits BclX [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_24" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_22 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <or/>
+                    <apply>
+                      <eq/>
+                      <ci> S_32 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <eq/>
+                      <ci> S_34 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_26">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">NFkB inhibits A20 [1].&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_26_in_S_22" qual:qualitativeSpecies="S_22" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>NFkB exerts negative feedback regulation on its own inducing pathway via activating A20 and IkB [1,2,3].</p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_26" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_22 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_27">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">APC, Cas6, and Cas8 can each activate Cas3. IAP is a negative regulator of Cas3 and is dominant over all positive regulators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_27_in_S_38" qual:qualitativeSpecies="S_38" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>\r\n	\r\n	\r\n		&lt;div class="page" title="Page 3">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2">IAP is a negative regulator of Cas3 [1,2,3].&amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_27_in_S_28" qual:qualitativeSpecies="S_28" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="background-color: rgb(255, 255, 255);">&lt;font face="Georgia" size="2">Caspase 8 is can activate caspase 3 [1,2,3].&amp;nbsp;&lt;/font>&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_27_in_S_31" qual:qualitativeSpecies="S_31" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>\r\n	\r\n	\r\n		&lt;div class="page" title="Page 3">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2">Caspase 6 is performs a positive feedback on Caspase 3 [1,2,3].&amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_27_in_S_35" qual:qualitativeSpecies="S_35" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>\r\n	\r\n	\r\n		&lt;div class="page" title="Page 3">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2" style="background-color: rgb(255, 255, 255);">The activation of caspase 3 involves APC [1,2,3]. &amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_27" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <or/>
+                  <apply>
+                    <and/>
+                    <apply>
+                      <eq/>
+                      <ci> S_35 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <not/>
+                      <apply>
+                        <eq/>
+                        <ci> S_38 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <and/>
+                    <apply>
+                      <eq/>
+                      <ci> S_31 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <not/>
+                      <apply>
+                        <eq/>
+                        <ci> S_38 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_28 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_38 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_28">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Cas6 and FADD can each independently activate cas8. cFlip is an inhibitor of cas8 and is dominant over both activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_28_in_S_14" qual:qualitativeSpecies="S_14" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">cFLIP is an inhibitory protein of caspase 8 [1,3,4,5,6,7].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_28_in_S_41" qual:qualitativeSpecies="S_41" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Activation of FADD causes the activation of caspase 8 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_28_in_S_31" qual:qualitativeSpecies="S_31" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Caspase 6 has a positive feedback effect upon caspase 8 [1,8,9].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_28" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_41 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_14 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_31 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_14 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_30">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>DNADamageEvent activates Apoptosis.</p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_30_in_S_20" qual:qualitativeSpecies="S_20" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>If DNA damage persists, the cell will undergo apoptosis. This is modeled by having DNADamageEvent activate Apoptosis only if DNADamageEvent is ON for 20 continuous steps.</p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_30" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_20 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_31">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Cas3 is positive regulator of Cas6 and IAP is a negative regulator of Cas6 and is dominant over Cas3 [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_31_in_S_27" qual:qualitativeSpecies="S_27" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Cas3 is a positive regulator of Cas6 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_31_in_S_38" qual:qualitativeSpecies="S_38" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">IAP is a negative regulator of Cas6 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_31" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_27 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_38 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_32">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia">DNADamageEvent and JNK each activate p53. Mdm2 inhibits p53 and is dominant over both activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_32_in_S_36" qual:qualitativeSpecies="S_36" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">Mdm2 inhibits p53 [1,4,5,6].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_32_in_S_20" qual:qualitativeSpecies="S_20" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">DNADamageEvent activates p53 [1,4,5,6].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_32_in_S_18" qual:qualitativeSpecies="S_18" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia">JNK activates p53 through the mitogen-activated protein kinase cascade [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_32" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_20 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_36 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_18 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_36 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_33">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">GFR activates PI3K [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_33_in_S_2" qual:qualitativeSpecies="S_2" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font size="2" face="Georgia">GFR activates PI3K [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_33" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_2 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_34">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>\r\n	\r\n	\r\n		&lt;div class="page" title="Page 3">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2">BAD is activated by p53 and inactivated by AKT [1].&amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_34_in_S_23" qual:qualitativeSpecies="S_23" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BAD is suppressed by pro-survival signals from Akt &amp;nbsp;[1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_34_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BAD is activated by pro-apoptotic signals from p53 [1,2].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_34" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_32 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_23 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_35">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>\r\n	\r\n	\r\n		&lt;div class="page" title="Page 3">\r\n			&lt;div class="layoutArea">\r\n				&lt;div class="column">\r\n					&lt;p>&lt;font face="Georgia" size="2">Apaf1, Casp9 and Mito are all required to activate APC. IAP inhibits APC [1].&amp;nbsp;&lt;/font>&lt;/p>\r\n				&lt;/div>\r\n			&lt;/div>\r\n		&lt;/div></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_35_in_S_39" qual:qualitativeSpecies="S_39" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">APC requires Cas9 to be activated [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_35_in_S_38" qual:qualitativeSpecies="S_38" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Inhibitors of apoptosis inhibit APC [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_35_in_S_15" qual:qualitativeSpecies="S_15" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">The mitochondrion releases other factors that overcome the inhibition of IAP and are collectively called Mito. These suppress the inhibition of IAP and thus activate APC [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_35_in_S_7" qual:qualitativeSpecies="S_7" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">APC requires Apaf1 to be activated [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_35" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_39 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <and/>
+                    <apply>
+                      <eq/>
+                      <ci> S_15 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <eq/>
+                      <ci> S_7 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <eq/>
+                    <ci> S_38 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_36">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">AKt and p53 each activate Mdm2 [1].&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_36_in_S_23" qual:qualitativeSpecies="S_23" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">AKT activates Mdm2 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_36_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">p53 activates Mdm2 [1].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_36" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <eq/>
+                  <ci> S_32 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <eq/>
+                  <ci> S_23 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_37">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">Cas7 activates Cas12 [1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_37_in_S_3" qual:qualitativeSpecies="S_3" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Cas7 activates Cas12 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_37" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_3 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_38">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;span style="font-family: Georgia; font-size: small;">NFkB activates IAP. Mito can inhibit IAP and Cas3 and Cas6 jointly inhibit IAP. All inhibitors are dominant over activators[1].&amp;nbsp;&lt;/span></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_38_in_S_27" qual:qualitativeSpecies="S_27" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Cas3 and Cas6 jointly inhibit IAP [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_38_in_S_22" qual:qualitativeSpecies="S_22" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">NFkB activates IAP [1,2,3].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_38_in_S_15" qual:qualitativeSpecies="S_15" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">The mitochondria component is a direct inhibitor of IAP [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_38_in_S_31" qual:qualitativeSpecies="S_31" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">Cas3 and Cas6 jointly inhibit IAP [1].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_38" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <and/>
+                <apply>
+                  <eq/>
+                  <ci> S_22 </ci>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <not/>
+                  <apply>
+                    <or/>
+                    <apply>
+                      <and/>
+                      <apply>
+                        <eq/>
+                        <ci> S_27 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                      <apply>
+                        <eq/>
+                        <ci> S_31 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                    </apply>
+                    <apply>
+                      <eq/>
+                      <ci> S_15 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_39">
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_39_in_S_23" qual:qualitativeSpecies="S_23" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">The pro-survival effects of Akt are expressed by Akt's inhibition of cas9 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_39_in_S_27" qual:qualitativeSpecies="S_27" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Caspase 3 has a positive feedback effect on caspase 9 [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_39_in_S_38" qual:qualitativeSpecies="S_38" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">IAP inhibits caspase 9 [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_39_in_S_37" qual:qualitativeSpecies="S_37" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Caspase 12 activates caspase 9 [1].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_39" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_37 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <or/>
+                      <apply>
+                        <eq/>
+                        <ci> S_23 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                      <apply>
+                        <eq/>
+                        <ci> S_38 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <eq/>
+                    <ci> S_27 </ci>
+                    <cn type="integer"> 1 </cn>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <or/>
+                      <apply>
+                        <eq/>
+                        <ci> S_23 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                      <apply>
+                        <eq/>
+                        <ci> S_38 </ci>
+                        <cn type="integer"> 1 </cn>
+                      </apply>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_40">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">Cas8 and JNK are activators of BID but both require the presence of p53 to activate BID. BclX is an inhibitor of BID and is dominant over all activators [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_40_in_S_32" qual:qualitativeSpecies="S_32" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">p53 activates BID [1,2,3].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_40_in_S_28" qual:qualitativeSpecies="S_28" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">Cas8 activates BID [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_40_in_S_18" qual:qualitativeSpecies="S_18" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;span style="font-family: Georgia; font-size: small;">JNK activates BID [1,2,3].&amp;nbsp;&lt;/span></p></body>
+            </notes>
+          </qual:input>
+          <qual:input qual:id="tr_S_40_in_S_24" qual:qualitativeSpecies="S_24" qual:sign="negative" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">BclX inhibits BID [1,2,3].&amp;nbsp;&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_40" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <or/>
+                <apply>
+                  <and/>
+                  <apply>
+                    <and/>
+                    <apply>
+                      <eq/>
+                      <ci> S_18 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <eq/>
+                      <ci> S_32 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_24 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <and/>
+                  <apply>
+                    <and/>
+                    <apply>
+                      <eq/>
+                      <ci> S_28 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                    <apply>
+                      <eq/>
+                      <ci> S_32 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <not/>
+                    <apply>
+                      <eq/>
+                      <ci> S_24 </ci>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+      <qual:transition qual:id="tr_S_41">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <p>&lt;font face="Georgia" size="2">TRADD activates FADD [1].&amp;nbsp;&lt;/font></p></body>
+        </notes>
+        <qual:listOfInputs>
+          <qual:input qual:id="tr_S_41_in_S_13" qual:qualitativeSpecies="S_13" qual:sign="positive" qual:thresholdLevel="1" qual:transitionEffect="none">
+            <notes>
+              <body xmlns="http://www.w3.org/1999/xhtml">
+                <p>&lt;font face="Georgia" size="2">TRADD activates FADD [1,2].&lt;/font></p></body>
+            </notes>
+          </qual:input>
+        </qual:listOfInputs>
+        <qual:listOfOutputs>
+          <qual:output qual:qualitativeSpecies="S_41" qual:transitionEffect="assignmentLevel"/>
+        </qual:listOfOutputs>
+        <qual:listOfFunctionTerms>
+          <qual:defaultTerm qual:resultLevel="0">
+          </qual:defaultTerm>
+          <qual:functionTerm qual:resultLevel="1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">            
+              <apply>
+                <eq/>
+                <ci> S_13 </ci>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </math>
+                    </qual:functionTerm>
+        </qual:listOfFunctionTerms>
+      </qual:transition>
+    </qual:listOfTransitions>
+    <listOfCompartments>
+      <compartment constant="true" id="extracellular" name="extracellular"/>
+      <compartment constant="true" id="cytosol" name="cytosol"/>
+    </listOfCompartments>
+  </model>
+</sbml>

--- a/sbml_models/apoptosis_stable.sbml
+++ b/sbml_models/apoptosis_stable.sbml
@@ -1,0 +1,1596 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:qual="http://www.sbml.org/sbml/level3/version1/qual/version1" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" level="3" version="1" layout:required="false" qual:required="true">
+   <model id="model_id">
+      <listOfCompartments>
+         <compartment constant="true" id="comp1" />
+      </listOfCompartments>
+      <layout:listOfLayouts>
+         <layout:layout id="layout1">
+            <layout:dimensions width="1350" height="1200" />
+            <layout:listOfAdditionalGraphicalObjects>
+               <layout:generalGlyph layout:reference="csa2" layout:id="csa2_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="360.0" layout:y="79.75" />
+                     <layout:dimensions layout:height="120.25" layout:width="101.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="csa3" layout:id="csa3_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="1149.0" layout:y="615.0" />
+                     <layout:dimensions layout:height="150.0" layout:width="140.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="csa5" layout:id="csa5_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="486.0" layout:y="693.0" />
+                     <layout:dimensions layout:height="148.0" layout:width="146.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="csa1" layout:id="csa1_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="710.0" layout:y="83.0" />
+                     <layout:dimensions layout:height="120.0" layout:width="101.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="csa6" layout:id="csa6_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="822.125" layout:y="234.375" />
+                     <layout:dimensions layout:height="117.0" layout:width="117.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="csa11" layout:id="csa11_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="1013.0" layout:y="470.5" />
+                     <layout:dimensions layout:height="156.0" layout:width="111.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa10" layout:id="sa10_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="532.0" layout:y="273.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa14" layout:id="sa14_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="321.125" layout:y="421.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa17" layout:id="sa17_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="321.125" layout:y="631.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa19" layout:id="sa19_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="469.125" layout:y="511.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa23" layout:id="sa23_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="809.125" layout:y="409.5" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa25" layout:id="sa25_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="998.0" layout:y="743.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa27" layout:id="sa27_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="975.0" layout:y="682.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa29" layout:id="sa29_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="775.0" layout:y="595.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa31" layout:id="sa31_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="1140.0" layout:y="958.75" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa40" layout:id="sa40_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="367.125" layout:y="751.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa41" layout:id="sa41_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="600.0" layout:y="1014.5" />
+                     <layout:dimensions layout:height="65.0" layout:width="240.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa42" layout:id="sa42_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="672.0" layout:y="661.5" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa43" layout:id="sa43_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="904.0" layout:y="358.5" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa44" layout:id="sa44_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="649.125" layout:y="226.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa47" layout:id="sa47_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="880.0" layout:y="683.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa48" layout:id="sa48_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="784.0" layout:y="878.5" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa50" layout:id="sa50_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="896.125" layout:y="820.375" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa69" layout:id="sa69_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="904.0" layout:y="409.5" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa72" layout:id="sa72_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="895.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa73" layout:id="sa73_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="940.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa74" layout:id="sa74_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="985.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa75" layout:id="sa75_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="850.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa76" layout:id="sa76_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="805.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa77" layout:id="sa77_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="250.0" layout:y="1030.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+               <layout:generalGlyph layout:reference="sa79" layout:id="sa79_glyph">
+                  <layout:boundingBox>
+                     <layout:position layout:x="904.0" layout:y="464.0" />
+                     <layout:dimensions layout:height="40.0" layout:width="80.0" />
+                  </layout:boundingBox>
+               </layout:generalGlyph>
+            </layout:listOfAdditionalGraphicalObjects>
+         </layout:layout>
+      </layout:listOfLayouts>
+      <qual:listOfQualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FAS/FASL_complex" qual:constant="true" qual:id="csa2">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s2">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:FAS/FASL_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s2" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BAD/BBC3/BCL2L11_complex" qual:constant="false" qual:id="csa3">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s143">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:BCL2/MCL1/BCL2L1_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s143" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Apoptosome_complex" qual:constant="false" qual:id="csa5">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s33">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CYCS&amp;APAF1&amp;CASP9_Cytoplasm&amp;!AKT1" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s33" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TNF/TNFRSF1A_complex" qual:constant="true" qual:id="csa1">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s160">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:TNF/TNFRSF1A_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s160" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TRADD/FADD_complex" qual:constant="false" qual:id="csa6">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s41">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:FADD&amp;TRADD&amp;TNF/TNFRSF1A_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s41" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BCL2/MCL1/BCL2L1_complex" qual:constant="false" qual:id="csa11">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s156">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf7a|E&amp;!BAD" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s156" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FADD" qual:constant="false" qual:id="sa10">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s111">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:FAS/FASL_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s111" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP8" qual:constant="false" qual:id="sa14">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s112">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:FADD|TRADD/FADD_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s112" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP3" qual:constant="false" qual:id="sa17">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s113">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CASP8|CASP9_Cytoplasm" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s113" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP9_Cytoplasm" qual:constant="false" qual:id="sa19">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s114">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Apoptosome_complex&amp;!AKT1" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s114" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BID" qual:constant="false" qual:id="sa23">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s115">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CASP8" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s115" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CYCS" qual:constant="false" qual:id="sa25">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s20">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:MAPK14" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s20" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="APAF1" qual:constant="true" qual:id="sa27">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s21">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:APAF1" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s21" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="AKT1" qual:constant="false" qual:id="sa29">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s116">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:!M" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s116" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BAX" qual:constant="false" qual:id="sa31">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s151">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:BID|BAD/BBC3/BCL2L11_complex&amp;!BCL2/MCL1/BCL2L1_complex" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s151" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP7" qual:constant="false" qual:id="sa40">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s117">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CASP9_Cytoplasm|CASP8" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s117" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Apoptosis_phenotype" qual:constant="false" qual:id="sa41">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s37">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:mesh:D017209" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CASP7|Orf3b|Orf8a|N|S|Orf9b|Orf6|CASP3" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s37" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="M" qual:constant="true" qual:id="sa42">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s38">
+                     <bqbiol:isEncodedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:ncbiprotein:APO40582" />
+                        </rdf:Bag>
+                     </bqbiol:isEncodedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:M" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s38" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf7a" qual:constant="true" qual:id="sa43">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s39">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf7a" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s39" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TRADD" qual:constant="true" qual:id="sa44">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s40">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:TRADD" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s40" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP9_Cytoplasm" qual:constant="true" qual:id="sa47">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s114">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:CASP9_Cytoplasm" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s114" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf3a" qual:constant="true" qual:id="sa48">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s45">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf3a" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s45" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="MAPK14" qual:constant="false" qual:id="sa50">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s118">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf3a" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s118" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="E" qual:constant="true" qual:id="sa69">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s94">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:E" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s94" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf3b" qual:constant="true" qual:id="sa72">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s144">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf3b" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s144" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf8a" qual:constant="true" qual:id="sa73">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s145">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf8a" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s145" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="N" qual:constant="true" qual:id="sa74">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s146">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:N" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s146" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf6" qual:constant="true" qual:id="sa75">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s147">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf6" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s147" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="S" qual:constant="true" qual:id="sa76">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s148">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:S" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s148" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf9b" qual:constant="true" qual:id="sa77">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s149">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:Orf9b" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s149" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+         <qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BAD" qual:constant="false" qual:id="sa79">
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#s150">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:function:!AKT1" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:casq:cdid:s150" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:qualitativeSpecies>
+      </qual:listOfQualitativeSpecies>
+      <qual:listOfTransitions>
+         <qual:transition qual:id="tr_csa3">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="csa11" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa3_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="csa3" qual:transitionEffect="assignmentLevel" qual:id="tr_csa3_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>csa11</ci>
+                        <cn type="integer">1</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re22">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_csa5">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa5_in_0" />
+               <qual:input qual:qualitativeSpecies="sa27" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa5_in_1" />
+               <qual:input qual:qualitativeSpecies="sa47" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa5_in_2" />
+               <qual:input qual:qualitativeSpecies="sa29" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_csa5_in_3" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="csa5" qual:transitionEffect="assignmentLevel" qual:id="tr_csa5_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <and />
+                        <apply>
+                           <eq />
+                           <ci>sa25</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa27</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa47</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa29</ci>
+                           <cn type="integer">0</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re30">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_csa6">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa10" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa6_in_0" />
+               <qual:input qual:qualitativeSpecies="sa44" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa6_in_1" />
+               <qual:input qual:qualitativeSpecies="csa1" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa6_in_2" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="csa6" qual:transitionEffect="assignmentLevel" qual:id="tr_csa6_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <and />
+                        <apply>
+                           <eq />
+                           <ci>sa10</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa44</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>csa1</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re16">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_csa11">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa11_in_0" />
+               <qual:input qual:qualitativeSpecies="sa69" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa11_in_1" />
+               <qual:input qual:qualitativeSpecies="sa79" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_csa11_in_2" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="csa11" qual:transitionEffect="assignmentLevel" qual:id="tr_csa11_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <and />
+                        <apply>
+                           <or />
+                           <apply>
+                              <eq />
+                              <ci>sa43</ci>
+                              <cn type="integer">1</cn>
+                           </apply>
+                           <apply>
+                              <eq />
+                              <ci>sa69</ci>
+                              <cn type="integer">1</cn>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa79</ci>
+                           <cn type="integer">0</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re23">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:15694340" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa10">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="csa2" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa10_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa10" qual:transitionEffect="assignmentLevel" qual:id="tr_sa10_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>csa2</ci>
+                        <cn type="integer">1</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re3">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa14">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa10" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa14_in_0" />
+               <qual:input qual:qualitativeSpecies="csa6" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa14_in_1" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa14" qual:transitionEffect="assignmentLevel" qual:id="tr_sa14_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <or />
+                        <apply>
+                           <eq />
+                           <ci>sa10</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>csa6</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re5">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa17">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa17_in_0" />
+               <qual:input qual:qualitativeSpecies="sa19" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa17_in_1" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa17" qual:transitionEffect="assignmentLevel" qual:id="tr_sa17_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <or />
+                        <apply>
+                           <eq />
+                           <ci>sa14</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa19</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re6">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa19">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="csa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa19_in_0" />
+               <qual:input qual:qualitativeSpecies="sa29" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa19_in_1" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa19" qual:transitionEffect="assignmentLevel" qual:id="tr_sa19_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <and />
+                        <apply>
+                           <eq />
+                           <ci>csa5</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa29</ci>
+                           <cn type="integer">0</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re7">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa23">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa23_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa23" qual:transitionEffect="assignmentLevel" qual:id="tr_sa23_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>sa14</ci>
+                        <cn type="integer">1</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re8">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa25">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa50" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa25_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa25" qual:transitionEffect="assignmentLevel" qual:id="tr_sa25_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>sa50</ci>
+                        <cn type="integer">1</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re10">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa29">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa42" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa29_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa29" qual:transitionEffect="assignmentLevel" qual:id="tr_sa29_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>sa42</ci>
+                        <cn type="integer">0</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re15">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa31">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa23" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_0" />
+               <qual:input qual:qualitativeSpecies="csa3" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_1" />
+               <qual:input qual:qualitativeSpecies="csa11" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa31_in_2" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa31" qual:transitionEffect="assignmentLevel" qual:id="tr_sa31_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <and />
+                        <apply>
+                           <or />
+                           <apply>
+                              <eq />
+                              <ci>sa23</ci>
+                              <cn type="integer">1</cn>
+                           </apply>
+                           <apply>
+                              <eq />
+                              <ci>csa3</ci>
+                              <cn type="integer">1</cn>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>csa11</ci>
+                           <cn type="integer">0</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re9">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa40">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa19" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa40_in_0" />
+               <qual:input qual:qualitativeSpecies="sa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa40_in_1" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa40" qual:transitionEffect="assignmentLevel" qual:id="tr_sa40_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <or />
+                        <apply>
+                           <eq />
+                           <ci>sa19</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa14</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re12">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa41">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa40" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_0" />
+               <qual:input qual:qualitativeSpecies="sa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_1" />
+               <qual:input qual:qualitativeSpecies="sa73" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_2" />
+               <qual:input qual:qualitativeSpecies="sa74" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_3" />
+               <qual:input qual:qualitativeSpecies="sa76" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_4" />
+               <qual:input qual:qualitativeSpecies="sa77" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_5" />
+               <qual:input qual:qualitativeSpecies="sa75" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_6" />
+               <qual:input qual:qualitativeSpecies="sa17" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa41_in_7" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa41" qual:transitionEffect="assignmentLevel" qual:id="tr_sa41_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <or />
+                        <apply>
+                           <eq />
+                           <ci>sa40</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa72</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa73</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa74</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa76</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa77</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa75</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                        <apply>
+                           <eq />
+                           <ci>sa17</ci>
+                           <cn type="integer">1</cn>
+                        </apply>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re14">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re27">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re28">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re29">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re31">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re32">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re33">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+                  <rdf:Description rdf:about="#re35">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa50">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa48" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa50_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa50" qual:transitionEffect="assignmentLevel" qual:id="tr_sa50_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>sa48</ci>
+                        <cn type="integer">1</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re19">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:31226023" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:taxonomy:227984" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+         <qual:transition qual:id="tr_sa79">
+            <qual:listOfInputs>
+               <qual:input qual:qualitativeSpecies="sa29" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa79_in_0" />
+            </qual:listOfInputs>
+            <qual:listOfOutputs>
+               <qual:output qual:qualitativeSpecies="sa79" qual:transitionEffect="assignmentLevel" qual:id="tr_sa79_out" />
+            </qual:listOfOutputs>
+            <qual:listOfFunctionTerms>
+               <qual:defaultTerm qual:resultLevel="0" />
+               <qual:functionTerm qual:resultLevel="1">
+                  <math xmlns="http://www.w3.org/1998/Math/MathML">
+                     <apply>
+                        <eq />
+                        <ci>sa29</ci>
+                        <cn type="integer">0</cn>
+                     </apply>
+                  </math>
+               </qual:functionTerm>
+            </qual:listOfFunctionTerms>
+            <notes>
+               <html xmlns="http://www.w3.org/1999/xhtml">
+                  <head>
+                     <title />
+                  </head>
+                  <body>
+                     <p>Signor</p>
+                  </body>
+               </html>
+            </notes>
+            <annotation>
+               <rdf:RDF>
+                  <rdf:Description rdf:about="#re34">
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:pubmed:15694340" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                     <bqbiol:isDescribedBy>
+                        <rdf:Bag>
+                           <rdf:li rdf:resource="urn:miriam:kegg.pathway:hsa04210" />
+                        </rdf:Bag>
+                     </bqbiol:isDescribedBy>
+                  </rdf:Description>
+               </rdf:RDF>
+            </annotation>
+         </qual:transition>
+      </qual:listOfTransitions>
+   </model>
+</sbml>

--- a/sbml_models/hmox1_pathway.sbml
+++ b/sbml_models/hmox1_pathway.sbml
@@ -1,0 +1,2533 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sbml xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" level="3" version="1" layout:required="false" xmlns="http://www.sbml.org/sbml/level3/version1/core" qual:required="true" xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:qual="http://www.sbml.org/sbml/level3/version1/qual/version1"><model id="model_id"><listOfCompartments><compartment constant="true" id="comp1" /></listOfCompartments><layout:listOfLayouts><layout:layout id="layout1"><layout:dimensions width="10000" height="10000" /><layout:listOfAdditionalGraphicalObjects><layout:generalGlyph layout:reference="csa2" layout:id="csa2_glyph"><layout:boundingBox><layout:position layout:x="1086.375" layout:y="1004.75" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa4" layout:id="csa4_glyph"><layout:boundingBox><layout:position layout:x="1226.375" layout:y="1003.75" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa5" layout:id="csa5_glyph"><layout:boundingBox><layout:position layout:x="2325.625" layout:y="329.25" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa8" layout:id="csa8_glyph"><layout:boundingBox><layout:position layout:x="855.875" layout:y="411.75" /><layout:dimensions layout:height="196.0" layout:width="213.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa10" layout:id="csa10_glyph"><layout:boundingBox><layout:position layout:x="558.2750000000001" layout:y="416.5500000000002" /><layout:dimensions layout:height="187.0" layout:width="205.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa78" layout:id="csa78_glyph"><layout:boundingBox><layout:position layout:x="4284.75" layout:y="1198.5" /><layout:dimensions layout:height="183.0" layout:width="310.5" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa12" layout:id="csa12_glyph"><layout:boundingBox><layout:position layout:x="1816.875" layout:y="1739.75" /><layout:dimensions layout:height="118.0" layout:width="157.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa13" layout:id="csa13_glyph"><layout:boundingBox><layout:position layout:x="1586.875" layout:y="1744.75" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa14" layout:id="csa14_glyph"><layout:boundingBox><layout:position layout:x="2902.875" layout:y="367.75" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa81" layout:id="csa81_glyph"><layout:boundingBox><layout:position layout:x="4359.5" layout:y="927.0" /><layout:dimensions layout:height="186.0" layout:width="221.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa19" layout:id="csa19_glyph"><layout:boundingBox><layout:position layout:x="1260.0" layout:y="220.0" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa22" layout:id="csa22_glyph"><layout:boundingBox><layout:position layout:x="2090.875" layout:y="1740.75" /><layout:dimensions layout:height="118.0" layout:width="135.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa27" layout:id="csa27_glyph"><layout:boundingBox><layout:position layout:x="306.75" layout:y="1753.625" /><layout:dimensions layout:height="178.0" layout:width="105.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa29" layout:id="csa29_glyph"><layout:boundingBox><layout:position layout:x="298.1875" layout:y="1468.125" /><layout:dimensions layout:height="178.0" layout:width="105.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa30" layout:id="csa30_glyph"><layout:boundingBox><layout:position layout:x="299.1875" layout:y="1228.125" /><layout:dimensions layout:height="135.0" layout:width="103.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa31" layout:id="csa31_glyph"><layout:boundingBox><layout:position layout:x="54.40625" layout:y="1485.125" /><layout:dimensions layout:height="135.0" layout:width="103.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa32" layout:id="csa32_glyph"><layout:boundingBox><layout:position layout:x="213.375" layout:y="435.75" /><layout:dimensions layout:height="147.0" layout:width="212.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa15" layout:id="csa15_glyph"><layout:boundingBox><layout:position layout:x="2850.0" layout:y="610.0" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa68" layout:id="csa68_glyph"><layout:boundingBox><layout:position layout:x="3280.0" layout:y="568.125" /><layout:dimensions layout:height="111.875" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa80" layout:id="csa80_glyph"><layout:boundingBox><layout:position layout:x="4425.0" layout:y="655.0" /><layout:dimensions layout:height="170.0" layout:width="230.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa72" layout:id="csa72_glyph"><layout:boundingBox><layout:position layout:x="3903.5" layout:y="352.5" /><layout:dimensions layout:height="135.0" layout:width="133.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa69" layout:id="csa69_glyph"><layout:boundingBox><layout:position layout:x="3280.0" layout:y="458.75" /><layout:dimensions layout:height="102.5" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa101" layout:id="csa101_glyph"><layout:boundingBox><layout:position layout:x="1502.5" layout:y="915.0" /><layout:dimensions layout:height="130.0" layout:width="195.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa21" layout:id="csa21_glyph"><layout:boundingBox><layout:position layout:x="2511.875" layout:y="1134.75" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa79" layout:id="csa79_glyph"><layout:boundingBox><layout:position layout:x="4462.5" layout:y="405.0" /><layout:dimensions layout:height="170.0" layout:width="215.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa74" layout:id="csa74_glyph"><layout:boundingBox><layout:position layout:x="3585.0" layout:y="485.0" /><layout:dimensions layout:height="110.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa83" layout:id="csa83_glyph"><layout:boundingBox><layout:position layout:x="4980.0" layout:y="347.5" /><layout:dimensions layout:height="85.0" layout:width="200.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa89" layout:id="csa89_glyph"><layout:boundingBox><layout:position layout:x="4870.0" layout:y="777.5" /><layout:dimensions layout:height="85.0" layout:width="160.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa87" layout:id="csa87_glyph"><layout:boundingBox><layout:position layout:x="4835.0" layout:y="942.5" /><layout:dimensions layout:height="95.0" layout:width="230.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa85" layout:id="csa85_glyph"><layout:boundingBox><layout:position layout:x="4690.0" layout:y="405.0" /><layout:dimensions layout:height="70.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa86" layout:id="csa86_glyph"><layout:boundingBox><layout:position layout:x="4880.0" layout:y="652.5" /><layout:dimensions layout:height="75.0" layout:width="140.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa88" layout:id="csa88_glyph"><layout:boundingBox><layout:position layout:x="4950.0" layout:y="455.0" /><layout:dimensions layout:height="90.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa90" layout:id="csa90_glyph"><layout:boundingBox><layout:position layout:x="4803.75" layout:y="1156.875" /><layout:dimensions layout:height="126.25" layout:width="292.5" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa11" layout:id="csa11_glyph"><layout:boundingBox><layout:position layout:x="2295.875" layout:y="1413.75" /><layout:dimensions layout:height="121.0" layout:width="104.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa3" layout:id="csa3_glyph"><layout:boundingBox><layout:position layout:x="2850.0" layout:y="1976.0" /><layout:dimensions layout:height="120.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa93" layout:id="csa93_glyph"><layout:boundingBox><layout:position layout:x="3987.5" layout:y="1563.0" /><layout:dimensions layout:height="74.0" layout:width="225.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa94" layout:id="csa94_glyph"><layout:boundingBox><layout:position layout:x="4291.25" layout:y="1568.75" /><layout:dimensions layout:height="62.5" layout:width="217.5" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="csa17" layout:id="csa17_glyph"><layout:boundingBox><layout:position layout:x="2546.875" layout:y="699.75" /><layout:dimensions layout:height="101.0" layout:width="101.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa5" layout:id="sa5_glyph"><layout:boundingBox><layout:position layout:x="1159.375" layout:y="909.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa6" layout:id="sa6_glyph"><layout:boundingBox><layout:position layout:x="1832.875" layout:y="523.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa20" layout:id="sa20_glyph"><layout:boundingBox><layout:position layout:x="2223.5" layout:y="456.0" /><layout:dimensions layout:height="28.0" layout:width="93.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa21" layout:id="sa21_glyph"><layout:boundingBox><layout:position layout:x="1971.0" layout:y="1077.0" /><layout:dimensions layout:height="26.0" layout:width="58.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa22" layout:id="sa22_glyph"><layout:boundingBox><layout:position layout:x="2303.0" layout:y="1076.5" /><layout:dimensions layout:height="27.0" layout:width="74.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa23" layout:id="sa23_glyph"><layout:boundingBox><layout:position layout:x="2255.625" layout:y="661.75" /><layout:dimensions layout:height="26.0" layout:width="52.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa24" layout:id="sa24_glyph"><layout:boundingBox><layout:position layout:x="2097.5" layout:y="1118.5" /><layout:dimensions layout:height="23.0" layout:width="25.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa25" layout:id="sa25_glyph"><layout:boundingBox><layout:position layout:x="2049.5" layout:y="1095.5" /><layout:dimensions layout:height="29.0" layout:width="41.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa26" layout:id="sa26_glyph"><layout:boundingBox><layout:position layout:x="2336.0" layout:y="1106.5" /><layout:dimensions layout:height="27.0" layout:width="28.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa27" layout:id="sa27_glyph"><layout:boundingBox><layout:position layout:x="2252.0" layout:y="1109.0" /><layout:dimensions layout:height="22.0" layout:width="36.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa28" layout:id="sa28_glyph"><layout:boundingBox><layout:position layout:x="2138.125" layout:y="1330.75" /><layout:dimensions layout:height="37.0" layout:width="47.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa29" layout:id="sa29_glyph"><layout:boundingBox><layout:position layout:x="1750.0" layout:y="1140.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa30" layout:id="sa30_glyph"><layout:boundingBox><layout:position layout:x="2104.3458534708675" layout:y="720.8682030344781" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa31" layout:id="sa31_glyph"><layout:boundingBox><layout:position layout:x="2423.25" layout:y="1034.25" /><layout:dimensions layout:height="31.5" layout:width="33.5" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa32" layout:id="sa32_glyph"><layout:boundingBox><layout:position layout:x="2905.0" layout:y="1077.5" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa33" layout:id="sa33_glyph"><layout:boundingBox><layout:position layout:x="2447.0" layout:y="1107.5" /><layout:dimensions layout:height="25.0" layout:width="46.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa34" layout:id="sa34_glyph"><layout:boundingBox><layout:position layout:x="2749.5" layout:y="1099.0" /><layout:dimensions layout:height="22.0" layout:width="41.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa36" layout:id="sa36_glyph"><layout:boundingBox><layout:position layout:x="2619.875" layout:y="1135.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa39" layout:id="sa39_glyph"><layout:boundingBox><layout:position layout:x="2975.875" layout:y="1785.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa43" layout:id="sa43_glyph"><layout:boundingBox><layout:position layout:x="998.375" layout:y="909.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa44" layout:id="sa44_glyph"><layout:boundingBox><layout:position layout:x="1291.875" layout:y="910.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa48" layout:id="sa48_glyph"><layout:boundingBox><layout:position layout:x="1399.875" layout:y="954.25" /><layout:dimensions layout:height="24.0" layout:width="99.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa50" layout:id="sa50_glyph"><layout:boundingBox><layout:position layout:x="1256.875" layout:y="1150.25" /><layout:dimensions layout:height="26.0" layout:width="99.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa53" layout:id="sa53_glyph"><layout:boundingBox><layout:position layout:x="2370.625" layout:y="598.25" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa54" layout:id="sa54_glyph"><layout:boundingBox><layout:position layout:x="2512.625" layout:y="661.75" /><layout:dimensions layout:height="26.0" layout:width="54.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa55" layout:id="sa55_glyph"><layout:boundingBox><layout:position layout:x="2468.125" layout:y="699.75" /><layout:dimensions layout:height="23.0" layout:width="26.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa56" layout:id="sa56_glyph"><layout:boundingBox><layout:position layout:x="2385.125" layout:y="720.75" /><layout:dimensions layout:height="25.0" layout:width="51.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa57" layout:id="sa57_glyph"><layout:boundingBox><layout:position layout:x="2345.125" layout:y="704.75" /><layout:dimensions layout:height="21.0" layout:width="18.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa65" layout:id="sa65_glyph"><layout:boundingBox><layout:position layout:x="2179.625" layout:y="511.75" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa67" layout:id="sa67_glyph"><layout:boundingBox><layout:position layout:x="2281.125" layout:y="556.75" /><layout:dimensions layout:height="19.0" layout:width="28.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa68" layout:id="sa68_glyph"><layout:boundingBox><layout:position layout:x="2259.875" layout:y="532.25" /><layout:dimensions layout:height="21.0" layout:width="31.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa69" layout:id="sa69_glyph"><layout:boundingBox><layout:position layout:x="2499.875" layout:y="512.25" /><layout:dimensions layout:height="24.0" layout:width="46.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa70" layout:id="sa70_glyph"><layout:boundingBox><layout:position layout:x="2439.625" layout:y="458.75" /><layout:dimensions layout:height="20.0" layout:width="37.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa71" layout:id="sa71_glyph"><layout:boundingBox><layout:position layout:x="2464.625" layout:y="479.75" /><layout:dimensions layout:height="24.0" layout:width="43.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa72" layout:id="sa72_glyph"><layout:boundingBox><layout:position layout:x="2822.875" layout:y="512.25" /><layout:dimensions layout:height="23.0" layout:width="42.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa78" layout:id="sa78_glyph"><layout:boundingBox><layout:position layout:x="1831.875" layout:y="461.5500000000002" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa101" layout:id="sa101_glyph"><layout:boundingBox><layout:position layout:x="3017.875" layout:y="591.25" /><layout:dimensions layout:height="25.0" layout:width="42.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa103" layout:id="sa103_glyph"><layout:boundingBox><layout:position layout:x="3011.875" layout:y="470.25" /><layout:dimensions layout:height="23.0" layout:width="33.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa104" layout:id="sa104_glyph"><layout:boundingBox><layout:position layout:x="3016.375" layout:y="499.25" /><layout:dimensions layout:height="22.0" layout:width="24.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa105" layout:id="sa105_glyph"><layout:boundingBox><layout:position layout:x="3016.875" layout:y="720.25" /><layout:dimensions layout:height="26.0" layout:width="48.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa106" layout:id="sa106_glyph"><layout:boundingBox><layout:position layout:x="2977.875" layout:y="616.25" /><layout:dimensions layout:height="27.0" layout:width="39.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa107" layout:id="sa107_glyph"><layout:boundingBox><layout:position layout:x="2984.275" layout:y="704.35" /><layout:dimensions layout:height="25.0" layout:width="27.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa111" layout:id="sa111_glyph"><layout:boundingBox><layout:position layout:x="3019.875" layout:y="859.25" /><layout:dimensions layout:height="25.0" layout:width="47.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa112" layout:id="sa112_glyph"><layout:boundingBox><layout:position layout:x="2880.0" layout:y="780.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa113" layout:id="sa113_glyph"><layout:boundingBox><layout:position layout:x="2818.875" layout:y="974.25" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa114" layout:id="sa114_glyph"><layout:boundingBox><layout:position layout:x="2920.0" layout:y="890.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa115" layout:id="sa115_glyph"><layout:boundingBox><layout:position layout:x="2639.375" layout:y="969.0" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa116" layout:id="sa116_glyph"><layout:boundingBox><layout:position layout:x="2640.875" layout:y="812.25" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa117" layout:id="sa117_glyph"><layout:boundingBox><layout:position layout:x="2640.875" layout:y="663.25" /><layout:dimensions layout:height="25.0" layout:width="70.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa118" layout:id="sa118_glyph"><layout:boundingBox><layout:position layout:x="2526.875" layout:y="883.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa121" layout:id="sa121_glyph"><layout:boundingBox><layout:position layout:x="2605.875" layout:y="939.25" /><layout:dimensions layout:height="21.0" layout:width="24.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa122" layout:id="sa122_glyph"><layout:boundingBox><layout:position layout:x="2715.875" layout:y="867.25" /><layout:dimensions layout:height="20.0" layout:width="26.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa123" layout:id="sa123_glyph"><layout:boundingBox><layout:position layout:x="2714.875" layout:y="825.25" /><layout:dimensions layout:height="26.0" layout:width="31.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa124" layout:id="sa124_glyph"><layout:boundingBox><layout:position layout:x="2687.875" layout:y="770.25" /><layout:dimensions layout:height="20.0" layout:width="25.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa125" layout:id="sa125_glyph"><layout:boundingBox><layout:position layout:x="2693.875" layout:y="691.25" /><layout:dimensions layout:height="23.0" layout:width="29.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa126" layout:id="sa126_glyph"><layout:boundingBox><layout:position layout:x="1650.875" layout:y="424.75" /><layout:dimensions layout:height="30.0" layout:width="127.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa127" layout:id="sa127_glyph"><layout:boundingBox><layout:position layout:x="2751.5" layout:y="1704.5" /><layout:dimensions layout:height="51.0" layout:width="97.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa128" layout:id="sa128_glyph"><layout:boundingBox><layout:position layout:x="2253.5" layout:y="1715.5" /><layout:dimensions layout:height="29.0" layout:width="193.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa130" layout:id="sa130_glyph"><layout:boundingBox><layout:position layout:x="2556.0" layout:y="1716.0" /><layout:dimensions layout:height="28.0" layout:width="108.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa135" layout:id="sa135_glyph"><layout:boundingBox><layout:position layout:x="2005.5" layout:y="1933.5" /><layout:dimensions layout:height="38.0" layout:width="40.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa136" layout:id="sa136_glyph"><layout:boundingBox><layout:position layout:x="2262.875" layout:y="1377.25" /><layout:dimensions layout:height="23.0" layout:width="25.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa137" layout:id="sa137_glyph"><layout:boundingBox><layout:position layout:x="2245.875" layout:y="1359.25" /><layout:dimensions layout:height="21.0" layout:width="18.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa138" layout:id="sa138_glyph"><layout:boundingBox><layout:position layout:x="1740.5" layout:y="1935.5" /><layout:dimensions layout:height="36.0" layout:width="48.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa140" layout:id="sa140_glyph"><layout:boundingBox><layout:position layout:x="1249.875" layout:y="1402.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa141" layout:id="sa141_glyph"><layout:boundingBox><layout:position layout:x="2441.875" layout:y="1391.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa144" layout:id="sa144_glyph"><layout:boundingBox><layout:position layout:x="1248.875" layout:y="1359.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa145" layout:id="sa145_glyph"><layout:boundingBox><layout:position layout:x="1251.875" layout:y="1317.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa147" layout:id="sa147_glyph"><layout:boundingBox><layout:position layout:x="1273.875" layout:y="799.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa150" layout:id="sa150_glyph"><layout:boundingBox><layout:position layout:x="1247.875" layout:y="1233.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa151" layout:id="sa151_glyph"><layout:boundingBox><layout:position layout:x="1255.875" layout:y="1276.25" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa152" layout:id="sa152_glyph"><layout:boundingBox><layout:position layout:x="2482.875" layout:y="1336.25" /><layout:dimensions layout:height="26.0" layout:width="83.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa156" layout:id="sa156_glyph"><layout:boundingBox><layout:position layout:x="1938.5" layout:y="1905.5" /><layout:dimensions layout:height="23.0" layout:width="25.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa157" layout:id="sa157_glyph"><layout:boundingBox><layout:position layout:x="1924.5" layout:y="1890.5" /><layout:dimensions layout:height="21.0" layout:width="18.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa158" layout:id="sa158_glyph"><layout:boundingBox><layout:position layout:x="1796.5" layout:y="1903.5" /><layout:dimensions layout:height="27.0" layout:width="28.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa162" layout:id="sa162_glyph"><layout:boundingBox><layout:position layout:x="1489.5" layout:y="1933.5" /><layout:dimensions layout:height="38.0" layout:width="40.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa164" layout:id="sa164_glyph"><layout:boundingBox><layout:position layout:x="1285.875" layout:y="1772.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa165" layout:id="sa165_glyph"><layout:boundingBox><layout:position layout:x="2418.5" layout:y="1645.0" /><layout:dimensions layout:height="30.0" layout:width="163.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa166" layout:id="sa166_glyph"><layout:boundingBox><layout:position layout:x="2653.0" layout:y="1535.5" /><layout:dimensions layout:height="29.0" layout:width="114.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa167" layout:id="sa167_glyph"><layout:boundingBox><layout:position layout:x="2750.0" layout:y="1600.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa168" layout:id="sa168_glyph"><layout:boundingBox><layout:position layout:x="1920.0" layout:y="1140.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa169" layout:id="sa169_glyph"><layout:boundingBox><layout:position layout:x="1840.0" layout:y="1070.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa171" layout:id="sa171_glyph"><layout:boundingBox><layout:position layout:x="3050.0" layout:y="1710.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa189" layout:id="sa189_glyph"><layout:boundingBox><layout:position layout:x="1428.875" layout:y="595.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa190" layout:id="sa190_glyph"><layout:boundingBox><layout:position layout:x="1724.875" layout:y="594.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa3" layout:id="sa3_glyph"><layout:boundingBox><layout:position layout:x="1833.375" layout:y="664.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa195" layout:id="sa195_glyph"><layout:boundingBox><layout:position layout:x="1675.5" layout:y="1962.5" /><layout:dimensions layout:height="20.0" layout:width="20.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa196" layout:id="sa196_glyph"><layout:boundingBox><layout:position layout:x="2088.875" layout:y="157.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa197" layout:id="sa197_glyph"><layout:boundingBox><layout:position layout:x="1979.5" layout:y="91.5" /><layout:dimensions layout:height="26.0" layout:width="58.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa198" layout:id="sa198_glyph"><layout:boundingBox><layout:position layout:x="1791.875" layout:y="151.75" /><layout:dimensions layout:height="58.0" layout:width="98.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa203" layout:id="sa203_glyph"><layout:boundingBox><layout:position layout:x="1956.5" layout:y="687.5" /><layout:dimensions layout:height="25.0" layout:width="27.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa204" layout:id="sa204_glyph"><layout:boundingBox><layout:position layout:x="1945.0" layout:y="377.5" /><layout:dimensions layout:height="25.0" layout:width="30.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa205" layout:id="sa205_glyph"><layout:boundingBox><layout:position layout:x="1945.0" layout:y="422.0" /><layout:dimensions layout:height="16.0" layout:width="30.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa206" layout:id="sa206_glyph"><layout:boundingBox><layout:position layout:x="1956.0" layout:y="646.5" /><layout:dimensions layout:height="27.0" layout:width="28.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa211" layout:id="sa211_glyph"><layout:boundingBox><layout:position layout:x="1796.875" layout:y="1978.125" /><layout:dimensions layout:height="27.0" layout:width="28.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa212" layout:id="sa212_glyph"><layout:boundingBox><layout:position layout:x="1931.875" layout:y="1999.125" /><layout:dimensions layout:height="21.0" layout:width="18.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa213" layout:id="sa213_glyph"><layout:boundingBox><layout:position layout:x="1943.875" layout:y="1974.125" /><layout:dimensions layout:height="23.0" layout:width="25.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa214" layout:id="sa214_glyph"><layout:boundingBox><layout:position layout:x="1700.0" layout:y="2114.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa229" layout:id="sa229_glyph"><layout:boundingBox><layout:position layout:x="445.25" layout:y="1410.125" /><layout:dimensions layout:height="36.0" layout:width="48.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa238" layout:id="sa238_glyph"><layout:boundingBox><layout:position layout:x="569.75" layout:y="1409.625" /><layout:dimensions layout:height="38.0" layout:width="40.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa240" layout:id="sa240_glyph"><layout:boundingBox><layout:position layout:x="924.75" layout:y="1541.625" /><layout:dimensions layout:height="38.0" layout:width="40.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa241" layout:id="sa241_glyph"><layout:boundingBox><layout:position layout:x="712.875" layout:y="1346.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa242" layout:id="sa242_glyph"><layout:boundingBox><layout:position layout:x="486.75" layout:y="1451.625" /><layout:dimensions layout:height="20.0" layout:width="20.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa243" layout:id="sa243_glyph"><layout:boundingBox><layout:position layout:x="488.875" layout:y="1336.75" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa249" layout:id="sa249_glyph"><layout:boundingBox><layout:position layout:x="369.9749999999999" layout:y="633.9499999999998" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa362" layout:id="sa362_glyph"><layout:boundingBox><layout:position layout:x="3469.0" layout:y="406.5" /><layout:dimensions layout:height="27.0" layout:width="62.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa363" layout:id="sa363_glyph"><layout:boundingBox><layout:position layout:x="3469.5" layout:y="493.0" /><layout:dimensions layout:height="34.0" layout:width="61.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa364" layout:id="sa364_glyph"><layout:boundingBox><layout:position layout:x="3470.0" layout:y="572.5" /><layout:dimensions layout:height="35.0" layout:width="60.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa366" layout:id="sa366_glyph"><layout:boundingBox><layout:position layout:x="3497.25" layout:y="686.25" /><layout:dimensions layout:height="27.5" layout:width="65.5" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa367" layout:id="sa367_glyph"><layout:boundingBox><layout:position layout:x="1605.0" layout:y="827.5" /><layout:dimensions layout:height="25.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa375" layout:id="sa375_glyph"><layout:boundingBox><layout:position layout:x="4700.0" layout:y="860.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa376" layout:id="sa376_glyph"><layout:boundingBox><layout:position layout:x="4625.0" layout:y="1130.0" /><layout:dimensions layout:height="40.0" layout:width="110.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa377" layout:id="sa377_glyph"><layout:boundingBox><layout:position layout:x="4704.0" layout:y="324.0" /><layout:dimensions layout:height="52.0" layout:width="92.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa378" layout:id="sa378_glyph"><layout:boundingBox><layout:position layout:x="4882.5" layout:y="568.75" /><layout:dimensions layout:height="22.5" layout:width="135.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa379" layout:id="sa379_glyph"><layout:boundingBox><layout:position layout:x="4995.0" layout:y="590.0" /><layout:dimensions layout:height="20.0" layout:width="50.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa381" layout:id="sa381_glyph"><layout:boundingBox><layout:position layout:x="4485.0" layout:y="1385.0" /><layout:dimensions layout:height="30.0" layout:width="50.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa382" layout:id="sa382_glyph"><layout:boundingBox><layout:position layout:x="4550.0" layout:y="1485.0" /><layout:dimensions layout:height="30.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa385" layout:id="sa385_glyph"><layout:boundingBox><layout:position layout:x="4595.0" layout:y="1445.0" /><layout:dimensions layout:height="30.0" layout:width="110.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa460" layout:id="sa460_glyph"><layout:boundingBox><layout:position layout:x="3960.0" layout:y="1670.0" /><layout:dimensions layout:height="20.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa461" layout:id="sa461_glyph"><layout:boundingBox><layout:position layout:x="3580.0" layout:y="1678.75" /><layout:dimensions layout:height="22.5" layout:width="120.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa462" layout:id="sa462_glyph"><layout:boundingBox><layout:position layout:x="3845.0" layout:y="1555.0" /><layout:dimensions layout:height="30.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa463" layout:id="sa463_glyph"><layout:boundingBox><layout:position layout:x="3730.0" layout:y="1555.0" /><layout:dimensions layout:height="30.0" layout:width="100.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa464" layout:id="sa464_glyph"><layout:boundingBox><layout:position layout:x="3845.0" layout:y="1692.5" /><layout:dimensions layout:height="35.0" layout:width="90.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa465" layout:id="sa465_glyph"><layout:boundingBox><layout:position layout:x="3740.0" layout:y="1692.5" /><layout:dimensions layout:height="35.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa466" layout:id="sa466_glyph"><layout:boundingBox><layout:position layout:x="3850.0" layout:y="1860.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa467" layout:id="sa467_glyph"><layout:boundingBox><layout:position layout:x="3740.0" layout:y="1860.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa469" layout:id="sa469_glyph"><layout:boundingBox><layout:position layout:x="3520.0" layout:y="340.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa471" layout:id="sa471_glyph"><layout:boundingBox><layout:position layout:x="3670.0" layout:y="340.0" /><layout:dimensions layout:height="40.0" layout:width="80.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa493" layout:id="sa493_glyph"><layout:boundingBox><layout:position layout:x="3268.5" layout:y="735.0" /><layout:dimensions layout:height="30.0" layout:width="163.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa494" layout:id="sa494_glyph"><layout:boundingBox><layout:position layout:x="3802.5" layout:y="583.75" /><layout:dimensions layout:height="32.5" layout:width="215.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa495" layout:id="sa495_glyph"><layout:boundingBox><layout:position layout:x="3855.0" layout:y="510.0" /><layout:dimensions layout:height="40.0" layout:width="150.0" /></layout:boundingBox></layout:generalGlyph><layout:generalGlyph layout:reference="sa524" layout:id="sa524_glyph"><layout:boundingBox><layout:position layout:x="3538.5" layout:y="295.0" /><layout:dimensions layout:height="30.0" layout:width="163.0" /></layout:boundingBox></layout:generalGlyph></layout:listOfAdditionalGraphicalObjects></layout:layout></layout:listOfLayouts><qual:listOfQualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Nrf2/Maf_complex" qual:constant="false" qual:id="csa2"><annotation><rdf:RDF><rdf:Description rdf:about="#s36"><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus&amp;MAF" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s36" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description></rdf:RDF></annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BACH1/Maf_complex" qual:constant="false" qual:id="csa4"><annotation><rdf:RDF><rdf:Description rdf:about="#s44"><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:MAF&amp;BACH1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s44" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description></rdf:RDF></annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ALAS1:ALAS2_complex" qual:constant="true" qual:id="csa5"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s201">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P13196" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P22557" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ALAS1:ALAS2_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s201" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Ubiquitin Ligase Complex_complex_Cytosol" qual:constant="false" qual:id="csa8"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s197">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q15843" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:19940261" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:interpro:IPR000608" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:interpro:IPR000608" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q15843" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q15843" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:!CAND1|CUL3:RBX1_complex|NRF2_empty&amp;KEAP1&amp;!Dimethly fumarate_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s197" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Ubiquitin Ligase Complex_complex_Cytosol" qual:constant="false" qual:id="csa10"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s196">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q15843" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P0CG48" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:19940261" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:interpro:IPR000608" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Ubiquitin Ligase Complex_complex_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s196" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex" qual:constant="false" qual:id="csa78"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s441">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9ULZ3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3 oligomer:ASC_complex&amp;proCaspase-1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s441" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SLC40A1:CP:Cu2+_complex" qual:constant="false" qual:id="csa12"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s239">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P00450" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9NP59" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29036" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SLC40A1_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s239" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CYBRD1:Heme_complex" qual:constant="true" qual:id="csa13"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s162">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q53TN4" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30413" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CYBRD1:Heme_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s162" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ALAD:Zn2+_complex" qual:constant="true" qual:id="csa14"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s178">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P13716" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29105" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s178" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 elicitors:NLRP3 oligomer:ASC_complex" qual:constant="false" qual:id="csa81"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s444">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9ULZ3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A36080" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3 oligomer_complex&amp;ASC|NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex&amp;CTSG" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s444" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CUL3:RBX1_complex" qual:constant="true" qual:id="csa19"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s200">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CUL3:RBX1_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s200" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SLC40A1:HEPH:Cu2+_complex" qual:constant="true" qual:id="csa22"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s238">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9BQS7" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9NP59" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A28694" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s238" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TFRC:holoTF_complex_Cytosol" qual:constant="false" qual:id="csa27"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s265">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29034" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02786" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02786" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29034" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:TF_complex_Cytosol|Fe3+_ion_default_compartment&amp;Transferrin" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s265" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TFRC:holoTF_complex_Endosome Lumen" qual:constant="false" qual:id="csa29"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s289">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29034" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02786" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:holoTF_complex_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s289" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TFRC:TF_complex_Endosome Lumen" qual:constant="false" qual:id="csa30"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s290">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02786" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:holoTF_complex_Endosome Lumen" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s290" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TFRC:TF_complex_Cytosol" qual:constant="false" qual:id="csa31"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s288">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02786" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:TF_complex_Endosome Lumen" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s288" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Ubiquitin Ligase Complex_complex_Cytosol" qual:constant="false" qual:id="csa32"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s294">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q15843" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13618" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P62877" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P0CG48" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:19940261" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:interpro:IPR000608" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Ubiquitin Ligase Complex_complex_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s294" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="HMBS:DIPY_complex" qual:constant="true" qual:id="csa15"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s181">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A36319" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08397" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMBS:DIPY_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s181" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Oxidized thioredoxin:TXNIP_complex" qual:constant="true" qual:id="csa68"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s435">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P10599" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9H3M7" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Oxidized thioredoxin:TXNIP_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s435" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 elicitors:NLRP3 oligomer_complex" qual:constant="false" qual:id="csa80"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s443">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A36080" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s443" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3:SUGT1:HSP90_complex" qual:constant="false" qual:id="csa72"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s439">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08238" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y2Z0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08238" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y2Z0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08238" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y2Z0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 Elicitor Proteins&amp;NLRP3:SUGT1:HSP90_complex|NLRP3 Elicitor Small Molecules_simple_molecule&amp;NLRP3:SUGT1:HSP90_complex|TXNIP:NLRP3_complex|SARS E|SARS Orf3a|Reactive Oxygen Species_simple_molecule_Cytosol&amp;NLRP3" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s439" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Thioredoxin:TXNIP_complex" qual:constant="false" qual:id="csa69"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s436">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P10599" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9H3M7" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TXNIP&amp;TXN" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s436" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Nf-KB Complex_complex" qual:constant="true" qual:id="csa101"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s775">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P19838" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q04206" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q00653" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Nf-KB Complex_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s775" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BLVRA:Zn2+_complex" qual:constant="false" qual:id="csa21"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s217">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29805" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P53004" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:BLVRA_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s217" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 elicitors:NLRP3_complex" qual:constant="false" qual:id="csa79"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s442">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P05067" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P09616" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08238" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y2Z0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A46661" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16336" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30563" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A46661" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16336" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30563" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P09616" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P05067" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 Elicitor Small Molecules_simple_molecule&amp;NLRP3:SUGT1:HSP90_complex|NLRP3 Elicitor Proteins&amp;NLRP3:SUGT1:HSP90_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s442" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TXNIP:NLRP3_complex" qual:constant="false" qual:id="csa74"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s62">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9H3M7" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3&amp;TXNIP" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s62" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PSTPIP1 trimer:Pyrin trimer_complex" qual:constant="false" qual:id="csa83"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s121">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O15553" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O43586" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Pyrin trimer_complex&amp;PSTPIP1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s121" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dsDNA:AIM2 oligomer_complex" qual:constant="false" qual:id="csa89"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s454">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A36080" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dsDNA:AIM2_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s454" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dsDNA:AIM2 oligomer:ASC_complex" qual:constant="false" qual:id="csa87"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s451">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A36080" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9ULZ3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dsDNA:AIM2 oligomer_complex&amp;ASC" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s451" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Pyrin trimer_complex" qual:constant="true" qual:id="csa85"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s449">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O15553" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Pyrin trimer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s449" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dsDNA:AIM2_complex" qual:constant="false" qual:id="csa86"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s450">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16991" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O14862" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Double Strand DNA_simple_molecule&amp;AIM2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s450" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Pyrin trimer:ASC_complex" qual:constant="false" qual:id="csa88"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s452">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O15553" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9ULZ3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ASC&amp;Pyrin trimer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s452" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dsDNA:AIM2 oligomer:ASC:Procaspase-1_complex" qual:constant="false" qual:id="csa90"><annotation><rdf:RDF><rdf:Description rdf:about="#s455"><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dsDNA:AIM2 oligomer:ASC_complex&amp;proCaspase-1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s455" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description></rdf:RDF></annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Ferritin_complex" qual:constant="false" qual:id="csa11"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s132">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02794" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:FTH1_rna|FTL_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s132" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ALB/BIL_complex" qual:constant="false" qual:id="csa3"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s29">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02768" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16990" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16990" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02768" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Bilirubin_simple_molecule&amp;ABCC1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s29" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Caspase-1 Tetramer_complex" qual:constant="false" qual:id="csa93"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s458">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CASP1(120-197):CASP1(317-404)_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s458" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP1(120-197):CASP1(317-404)_complex" qual:constant="false" qual:id="csa94"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s156">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex&amp;CTSG|NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex&amp;CTSG" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s156" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PPO:FAD_complex" qual:constant="true" qual:id="csa17"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s184">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16238" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P50336" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PPO:FAD_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s184" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="MAF" qual:constant="true" qual:id="sa5"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s35">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O75444" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:MAF" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s35" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NRF2_empty" qual:constant="true" qual:id="sa6"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s32">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_empty" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s32" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Panhematin_drug" qual:constant="true" qual:id="sa20"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s8">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A50385" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Panhematin_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s8" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Heme_simple_molecule_Cytosol" qual:constant="false" qual:id="sa21"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s9">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30413" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Mitochondrial Matrix&amp;FLVCR1-2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s9" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Biliverdin_simple_molecule" qual:constant="false" qual:id="sa22"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s10">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A17033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s10" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Heme_simple_molecule_Mitochondrial Matrix" qual:constant="false" qual:id="sa23"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s11">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30413" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PRIN9_simple_molecule_Mitochondrial Matrix&amp;Fe2+_ion_Mitochondrial Matrix&amp;FECH&amp;!Pb2+_ion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s11" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_Cytosol" qual:constant="true" qual:id="sa24"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s12">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s12" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s12" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NADPH_simple_molecule_Cytosol" qual:constant="true" qual:id="sa25"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s13">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16474" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s13" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s13" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_Cytosol" qual:constant="false" qual:id="sa26"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s14">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NADP+_simple_molecule_Cytosol" qual:constant="false" qual:id="sa27"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s15">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A18009" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s15" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:BLVRB|BLVRA:Zn2+_complex&amp;Biliverdin_simple_molecule&amp;NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s15" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_Cytosol" qual:constant="false" qual:id="sa28"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s16">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol|Fe2+_ion_default_compartment&amp;SLC11A2|Fe2+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s16" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Endosome Lumen&amp;MCOLN1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s16" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="HMOX1_Cytosol" qual:constant="false" qual:id="sa29"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s17">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P09601" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMOX1_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s17" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMOX1_Cytosol&amp;SARS-CoV-2 Orf3a" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s17" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FLVCR1-2" qual:constant="true" qual:id="sa30"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s18">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y5Y0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:FLVCR1-2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s18" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CO_simple_molecule" qual:constant="false" qual:id="sa31"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s19">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A17245" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s19" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Bilirubin_simple_molecule" qual:constant="false" qual:id="sa32"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s20">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16990" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:BLVRB|BLVRA:Zn2+_complex&amp;Biliverdin_simple_molecule&amp;NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s20" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NADPH_simple_molecule_Cytosol" qual:constant="true" qual:id="sa33"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s13">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16474" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s13" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s13" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NADP+_simple_molecule_Cytosol" qual:constant="false" qual:id="sa34"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s15">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A18009" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s15" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:BLVRB|BLVRA:Zn2+_complex&amp;Biliverdin_simple_molecule&amp;NADPH_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s15" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BLVRB" qual:constant="false" qual:id="sa36"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s22">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P30043" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:BLVRB_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s22" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ABCC1" qual:constant="false" qual:id="sa39"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s26">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02768" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02768" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Orf9c" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s26" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NRF2_phosphorylated_Nucleus" qual:constant="false" qual:id="sa43"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s560">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s560" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BACH1" qual:constant="false" qual:id="sa44"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s43">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O14867" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:571" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:!miRNA-155_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s43" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="miRNA-155_rna" qual:constant="true" qual:id="sa48"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s48">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:406947" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:miRNA-155_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s48" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="HMOX1_rna" qual:constant="false" qual:id="sa50"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s50">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:3162" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:3162" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Nrf2/Maf_complex&amp;!BACH1/Maf_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s50" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FECH" qual:constant="false" qual:id="sa53"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s52">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P22830" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:FECH_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s52" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PRIN9_simple_molecule_Mitochondrial Matrix" qual:constant="false" qual:id="sa54"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s53">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15430" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PRIN9_simple_molecule_Mitochondrion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s53" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_Mitochondrial Matrix" qual:constant="true" qual:id="sa55"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s54">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Mitochondrial Matrix" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s54" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Pb2+_ion" qual:constant="true" qual:id="sa56"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s55">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A27889" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Pb2+_ion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s55" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_Mitochondrial Matrix" qual:constant="false" qual:id="sa57"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s56">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PRIN9_simple_molecule_Mitochondrial Matrix&amp;Fe2+_ion_Mitochondrial Matrix&amp;FECH&amp;!Pb2+_ion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s56" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_Mitochondrial Matrix" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s56" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SUCC-CoA_simple_molecule" qual:constant="true" qual:id="sa65"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s63">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A57292" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SUCC-CoA_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s63" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_Mitochondrial Matrix" qual:constant="true" qual:id="sa67"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s56">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PRIN9_simple_molecule_Mitochondrial Matrix&amp;Fe2+_ion_Mitochondrial Matrix&amp;FECH&amp;!Pb2+_ion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s56" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_Mitochondrial Matrix" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s56" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Gly_simple_molecule" qual:constant="true" qual:id="sa68"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s65">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A57305" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Gly_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s65" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dALA_simple_molecule_Mitochondrial Matrix" qual:constant="false" qual:id="sa69"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s66">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A356416" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SUCC-CoA_simple_molecule&amp;Gly_simple_molecule&amp;H+_ion_Mitochondrial Matrix&amp;ALAS1:ALAS2_complex&amp;!Heme_simple_molecule_Mitochondrial Matrix&amp;!Panhematin_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s66" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CO2_simple_molecule_Mitochondrial Matrix" qual:constant="false" qual:id="sa70"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s67">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16526" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SUCC-CoA_simple_molecule&amp;Gly_simple_molecule&amp;H+_ion_Mitochondrial Matrix&amp;ALAS1:ALAS2_complex&amp;!Heme_simple_molecule_Mitochondrial Matrix&amp;!Panhematin_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s67" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CoA-SH_simple_molecule" qual:constant="false" qual:id="sa71"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s68">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15346" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SUCC-CoA_simple_molecule&amp;Gly_simple_molecule&amp;H+_ion_Mitochondrial Matrix&amp;ALAS1:ALAS2_complex&amp;!Heme_simple_molecule_Mitochondrial Matrix&amp;!Panhematin_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s68" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="dALA_simple_molecule_Cytosol" qual:constant="false" qual:id="sa72"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s69">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A356416" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Mitochondrial Matrix" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s69" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="KEAP1" qual:constant="true" qual:id="sa78"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s75">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14145" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:KEAP1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s75" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PBG_simple_molecule" qual:constant="false" qual:id="sa101"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s99">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A58126" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s99" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_Cytosol" qual:constant="false" qual:id="sa103"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s14">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_Cytosol" qual:constant="false" qual:id="sa104"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s101">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s101" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s101" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="HMBL_simple_molecule" qual:constant="false" qual:id="sa105"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s102">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A57845" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PBG_simple_molecule&amp;H2O_simple_molecule_Cytosol&amp;HMBS:DIPY_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s102" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_Cytosol" qual:constant="true" qual:id="sa106"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s14">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NH4+_ion" qual:constant="false" qual:id="sa107"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s215">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A28938" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PBG_simple_molecule&amp;H2O_simple_molecule_Cytosol&amp;HMBS:DIPY_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s215" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="URO3_simple_molecule" qual:constant="false" qual:id="sa111"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s107">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15437" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMBL_simple_molecule&amp;UROS" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s107" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="UROS" qual:constant="true" qual:id="sa112"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s108">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P10746" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:UROS" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s108" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="COPRO3_simple_molecule_Cytosol" qual:constant="false" qual:id="sa113"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s109">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15439" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:URO3_simple_molecule&amp;UROD" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s109" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="UROD" qual:constant="true" qual:id="sa114"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s110">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P06132" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:UROD" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s110" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="COPRO3_simple_molecule_Mitochondrion" qual:constant="false" qual:id="sa115"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s114">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15439" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:COPRO3_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s114" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PPGEN9_simple_molecule" qual:constant="false" qual:id="sa116"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s117">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15435" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:COPRO3_simple_molecule_Mitochondrion&amp;O2_simple_molecule_Mitochondrion&amp;CPOX" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s117" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PRIN9_simple_molecule_Mitochondrion" qual:constant="false" qual:id="sa117"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s118">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15430" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PPGEN9_simple_molecule&amp;O2_simple_molecule_Mitochondrion&amp;PPO:FAD_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s118" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CPOX" qual:constant="true" qual:id="sa118"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s119">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P36551" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CPOX" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s119" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_Mitochondrion" qual:constant="true" qual:id="sa121"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s125">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Mitochondrion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s125" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Mitochondrion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s125" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CO2_simple_molecule_Mitochondrion" qual:constant="false" qual:id="sa122"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s123">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16526" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:COPRO3_simple_molecule_Mitochondrion&amp;O2_simple_molecule_Mitochondrion&amp;CPOX" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s123" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O2_simple_molecule_Mitochondrion" qual:constant="false" qual:id="sa123"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s124">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16240" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:COPRO3_simple_molecule_Mitochondrion&amp;O2_simple_molecule_Mitochondrion&amp;CPOX" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s124" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PPGEN9_simple_molecule&amp;O2_simple_molecule_Mitochondrion&amp;PPO:FAD_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s124" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_Mitochondrion" qual:constant="true" qual:id="sa124"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s125">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Mitochondrion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s125" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Mitochondrion" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s125" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O2_simple_molecule_Mitochondrion" qual:constant="false" qual:id="sa125"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s124">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16240" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:COPRO3_simple_molecule_Mitochondrion&amp;O2_simple_molecule_Mitochondrion&amp;CPOX" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s124" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PPGEN9_simple_molecule&amp;O2_simple_molecule_Mitochondrion&amp;PPO:FAD_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s124" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Dimethly fumarate_drug" qual:constant="true" qual:id="sa126"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s127">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A76004" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Dimethly fumarate_drug" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s127" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Ferroptosis_phenotype" qual:constant="false" qual:id="sa127"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s128">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.go:GO%3A0097707" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Lipid Peroxide_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s128" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Poly-unsaturated fatty acid_simple_molecule" qual:constant="true" qual:id="sa128"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s129">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A26208" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Poly-unsaturated fatty acid_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s129" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Lipid Peroxide_simple_molecule" qual:constant="false" qual:id="sa130"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s131">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A61051" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Poly-unsaturated fatty acid_simple_molecule&amp;Reactive Oxygen Species_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s131" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_default_compartment" qual:constant="false" qual:id="sa135"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s137">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol&amp;SLC40A1:CP:Cu2+_complex|Fe2+_ion_Cytosol&amp;SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s137" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe3+_ion_default_compartment&amp;e-_ion_default_compartment&amp;CYBRD1:Heme_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s137" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_Cytosol" qual:constant="true" qual:id="sa136"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s12">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s12" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s12" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_Cytosol" qual:constant="true" qual:id="sa137"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s101">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s101" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s101" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe3+_ion_default_compartment" qual:constant="false" qual:id="sa138"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s138">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29034" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;H+_ion_default_compartment&amp;SLC40A1:CP:Cu2+_complex|Fe2+_ion_default_compartment&amp;H+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s138" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SLC40A1_rna" qual:constant="false" qual:id="sa140"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s140">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:30061" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:30061" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s140" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NCOA4" qual:constant="true" qual:id="sa141"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s141">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q13772" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NCOA4" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s141" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FTH1_rna" qual:constant="false" qual:id="sa144"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s144">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2495" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2495" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s144" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FTL_rna" qual:constant="false" qual:id="sa145"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s145">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2512" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2512" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s145" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FECH_rna" qual:constant="false" qual:id="sa147"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s147">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2235" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:2235" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s147" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BLVRA_rna" qual:constant="false" qual:id="sa150"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s150">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:644" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:644" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s150" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="BLVRB_rna" qual:constant="false" qual:id="sa151"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s151">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:645" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:645" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_phosphorylated_Nucleus" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s151" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe(3+)O(OH)_simple_molecule" qual:constant="false" qual:id="sa152"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s153">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A78619" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol&amp;O2_simple_molecule_Cytosol&amp;H+_ion_Cytosol&amp;Ferritin_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s153" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_default_compartment" qual:constant="true" qual:id="sa156"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s158">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s158" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s158" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_default_compartment" qual:constant="true" qual:id="sa157"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s159">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s159" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s159" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_default_compartment" qual:constant="false" qual:id="sa158"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s160">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;H+_ion_default_compartment&amp;SLC40A1:CP:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s160" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_default_compartment&amp;H+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s160" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_default_compartment" qual:constant="false" qual:id="sa162"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s137">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol&amp;SLC40A1:CP:Cu2+_complex|Fe2+_ion_Cytosol&amp;SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s137" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe3+_ion_default_compartment&amp;e-_ion_default_compartment&amp;CYBRD1:Heme_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s137" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SLC11A2" qual:constant="true" qual:id="sa164"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s170">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P49281" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SLC11A2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s170" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Reactive Oxygen Species_simple_molecule_Cytosol" qual:constant="false" qual:id="sa165"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s171">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A26523" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Reactive Oxygen Species_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:!CO_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Lipid alcohol_simple_molecule" qual:constant="false" qual:id="sa166"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s172">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A24026" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Lipid Peroxide_simple_molecule&amp;GPX4" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s172" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="GPX4" qual:constant="true" qual:id="sa167"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s173">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P36969" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:GPX4" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s173" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="HMOX1_Cytosol" qual:constant="false" qual:id="sa168"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s17">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P09601" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMOX1_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s17" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:HMOX1_Cytosol&amp;SARS-CoV-2 Orf3a" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s17" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SARS-CoV-2 Orf3a" qual:constant="true" qual:id="sa169"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s174">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P0DTC3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:taxonomy:2697049" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SARS-CoV-2 Orf3a" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s174" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Orf9c" qual:constant="true" qual:id="sa171"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s176">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:taxonomy:2697049" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Orf9c" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s176" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CAND1" qual:constant="true" qual:id="sa189"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s211">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q86VP6" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CAND1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s211" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PKC" qual:constant="true" qual:id="sa190"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s212">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:12198130" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:is>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:interpro:IPR012233" />
+</rdf:Bag>
+</bqmodel:is>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PKC" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s212" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NRF2_phosphorylated_Cytosol" qual:constant="false" qual:id="sa3"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s33">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q16236" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NRF2_empty&amp;PKC" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s33" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="e-_ion_default_compartment" qual:constant="true" qual:id="sa195"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s220">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A10545" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:e-_ion_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s220" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="FLVCR1-1" qual:constant="true" qual:id="sa196"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s221">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9Y5Y0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:FLVCR1-1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s221" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Heme_simple_molecule_default_compartment" qual:constant="false" qual:id="sa197"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s222">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30413" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;FLVCR1-1|Heme_simple_molecule_Cytosol&amp;H2O_simple_molecule_Cytosol&amp;ATP_simple_molecule&amp;ABCG2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s222" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ABCG2" qual:constant="true" qual:id="sa198"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s223">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9UNQ0" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ABCG2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s223" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ATP_simple_molecule" qual:constant="true" qual:id="sa203"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s228">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30616" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ATP_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s228" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ADP_simple_molecule" qual:constant="false" qual:id="sa204"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s229">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A456216" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;H2O_simple_molecule_Cytosol&amp;ATP_simple_molecule&amp;ABCG2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s229" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Pi_simple_molecule" qual:constant="false" qual:id="sa205"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s230">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A18367" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;H2O_simple_molecule_Cytosol&amp;ATP_simple_molecule&amp;ABCG2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s230" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_Cytosol" qual:constant="true" qual:id="sa206"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s14">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:dALA_simple_molecule_Cytosol&amp;ALAD:Zn2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H2O_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s14" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H2O_simple_molecule_default_compartment" qual:constant="false" qual:id="sa211"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s160">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15377" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;H+_ion_default_compartment&amp;SLC40A1:CP:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s160" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_default_compartment&amp;H+_ion_default_compartment&amp;O2_simple_molecule_default_compartment&amp;SLC40A1:HEPH:Cu2+_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s160" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="H+_ion_default_compartment" qual:constant="true" qual:id="sa212"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s159">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15378" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s159" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:H+_ion_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s159" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="O2_simple_molecule_default_compartment" qual:constant="true" qual:id="sa213"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s158">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A15379" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s158" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:O2_simple_molecule_default_compartment" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s158" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Transferrin" qual:constant="false" qual:id="sa214"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s240">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P02787" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:TF_complex_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s240" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe3+_ion_Endosome Lumen" qual:constant="false" qual:id="sa229"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s270">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29034" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TFRC:holoTF_complex_Endosome Lumen" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s270" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_Endosome Lumen" qual:constant="false" qual:id="sa238"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s281">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe3+_ion_Endosome Lumen&amp;e-_ion_Endosome Lumen&amp;STEAP3" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s281" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Fe2+_ion_Cytosol" qual:constant="false" qual:id="sa240"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s16">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A29033" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Heme_simple_molecule_Cytosol&amp;O2_simple_molecule_Cytosol&amp;NADPH_simple_molecule_Cytosol&amp;HMOX1_Cytosol|Fe2+_ion_default_compartment&amp;SLC11A2|Fe2+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s16" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Endosome Lumen&amp;MCOLN1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s16" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="MCOLN1" qual:constant="true" qual:id="sa241"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s282">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9GZU1" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:MCOLN1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s282" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="e-_ion_Endosome Lumen" qual:constant="true" qual:id="sa242"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s283">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A10545" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:e-_ion_Endosome Lumen" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s283" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="STEAP3" qual:constant="true" qual:id="sa243"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s284">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q658P3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:STEAP3" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s284" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NRF2_ubiquitinated" qual:constant="false" qual:id="sa249"><annotation><rdf:RDF><rdf:Description rdf:about="#s299"><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Ubiquitin Ligase Complex_complex_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s299" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description></rdf:RDF></annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3" qual:constant="false" qual:id="sa362"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s3">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q96P20" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3_rna" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s3" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TXNIP" qual:constant="false" qual:id="sa363"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s417">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9H3M7" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Oxidized thioredoxin:TXNIP_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s417" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="TXN" qual:constant="true" qual:id="sa364"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s418">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P10599" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:TXN" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s418" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="2xHC-TXN" qual:constant="false" qual:id="sa366"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s420">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P10599" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Oxidized thioredoxin:TXNIP_complex|TXN&amp;Reactive Oxygen Species_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s420" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3_rna" qual:constant="false" qual:id="sa367"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s27">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:114548" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:ncbigene:114548" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Nf-KB Complex_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s27" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="ASC" qual:constant="true" qual:id="sa375"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s426">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q9ULZ3" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:ASC" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s426" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="proCaspase-1" qual:constant="true" qual:id="sa376"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s427">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proCaspase-1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s427" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="PSTPIP1" qual:constant="true" qual:id="sa377"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s122">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O43586" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:PSTPIP1" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s122" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Double Strand DNA_simple_molecule" qual:constant="true" qual:id="sa378"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s428">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16991" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Double Strand DNA_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s428" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="AIM2" qual:constant="true" qual:id="sa379"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s130">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:O14862" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:AIM2" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s130" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CTSG" qual:constant="true" qual:id="sa381"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s430">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P08311" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:CTSG" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s430" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP1(1-119)" qual:constant="false" qual:id="sa382"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s152">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex&amp;CTSG" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s152" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="CASP1(298-316)" qual:constant="false" qual:id="sa385"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s432">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P29466" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 elicitors:NLRP3 oligomer:ASC:Procaspase1_complex&amp;CTSG" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s432" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="proIL-1B(1-116)" qual:constant="false" qual:id="sa460"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s168">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P01584" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-1B&amp;Caspase-1 Tetramer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s168" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="proIL-18(1-36)" qual:constant="false" qual:id="sa461"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s169">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14116" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-18&amp;Caspase-1 Tetramer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s169" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="proIL-1B" qual:constant="true" qual:id="sa462"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s166">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P01584" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-1B" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s166" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="proIL-18" qual:constant="true" qual:id="sa463"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s515">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14116" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-18" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s515" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="IL-1B_Cytosol" qual:constant="false" qual:id="sa464"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s504">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P01584" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-1B&amp;Caspase-1 Tetramer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s504" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="IL-18_Cytosol" qual:constant="false" qual:id="sa465"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s516">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14116" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:proIL-18&amp;Caspase-1 Tetramer_complex" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s516" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="IL-1B_default_compartment" qual:constant="false" qual:id="sa466"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s507">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P01584" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:IL-1B_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s507" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="IL-18_default_compartment" qual:constant="false" qual:id="sa467"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s517">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:Q14116" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:IL-18_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s517" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SARS Orf3a" qual:constant="true" qual:id="sa469"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s779">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P59632" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SARS Orf3a" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s779" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="SARS E" qual:constant="true" qual:id="sa471"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s522">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P59637" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:SARS E" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s522" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Reactive Oxygen Species_simple_molecule_Cytosol" qual:constant="true" qual:id="sa493"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s171">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A26523" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Reactive Oxygen Species_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:!CO_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 Elicitor Small Molecules_simple_molecule" qual:constant="true" qual:id="sa494"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s537">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A46661" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A16336" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A30563" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 Elicitor Small Molecules_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s537" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="NLRP3 Elicitor Proteins" qual:constant="true" qual:id="sa495"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s538">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P05067" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:uniprot:P09616" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:NLRP3 Elicitor Proteins" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s538" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies><qual:qualitativeSpecies qual:maxLevel="1" qual:compartment="comp1" qual:name="Reactive Oxygen Species_simple_molecule_Cytosol" qual:constant="false" qual:id="sa524"><annotation><rdf:RDF>
+<rdf:Description rdf:about="#s171">
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:obo.chebi:CHEBI%3A26523" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+<bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Fe2+_ion_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:Reactive Oxygen Species_simple_molecule_Cytosol" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:function:!CO_simple_molecule" /></rdf:Bag></bqbiol:isDescribedBy><bqbiol:isDescribedBy><rdf:Bag><rdf:li rdf:resource="urn:casq:cdid:s171" /></rdf:Bag></bqbiol:isDescribedBy></rdf:Description>
+</rdf:RDF>
+</annotation></qual:qualitativeSpecies></qual:listOfQualitativeSpecies><qual:listOfTransitions><qual:transition qual:id="tr_csa2"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa2_in_0" /><qual:input qual:qualitativeSpecies="sa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa2_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa2" qual:transitionEffect="assignmentLevel" qual:id="tr_csa2_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa5</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re20">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31827672" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:29717933" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_csa4"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa4_in_0" /><qual:input qual:qualitativeSpecies="sa44" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa4_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa4" qual:transitionEffect="assignmentLevel" qual:id="tr_csa4_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa5</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa44</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://www.sciencedirect.com/science/article/pii/S0002944016305326
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re21">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:28082120" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_csa8"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa189" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_csa8_in_0" /><qual:input qual:qualitativeSpecies="csa19" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa8_in_1" /><qual:input qual:qualitativeSpecies="sa6" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa8_in_2" /><qual:input qual:qualitativeSpecies="sa78" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa8_in_3" /><qual:input qual:qualitativeSpecies="sa126" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_csa8_in_4" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa8" qual:transitionEffect="assignmentLevel" qual:id="tr_csa8_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><eq /><ci>sa189</ci><cn type="integer">0</cn></apply><apply><eq /><ci>csa19</ci><cn type="integer">1</cn></apply><apply><and /><apply><eq /><ci>sa6</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa126</ci><cn type="integer">0</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re95">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:20486766" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:15572695" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+<rdf:Description rdf:about="#re94">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:20486766" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:16449638" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:15572695" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+<rdf:Description rdf:about="#re92">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:20486766" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+<rdf:Description rdf:about="#re35">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:15282312" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:20486766" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:15572695" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:32132672" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_csa10"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa8" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa10_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa10" qual:transitionEffect="assignmentLevel" qual:id="tr_csa10_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa8</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2966484/figure/f5/
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re40">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:20486766" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:15572695" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_csa78"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa81" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa78_in_0" /><qual:input qual:qualitativeSpecies="sa376" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa78_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa78" qual:transitionEffect="assignmentLevel" qual:id="tr_csa78_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa81</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa376</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-844612.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa12"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa140" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa12_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa12" qual:transitionEffect="assignmentLevel" qual:id="tr_csa12_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa140</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_csa81"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa80" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa81_in_0" /><qual:input qual:qualitativeSpecies="sa375" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa81_in_1" /><qual:input qual:qualitativeSpecies="csa78" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa81_in_2" /><qual:input qual:qualitativeSpecies="sa381" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa81_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa81" qual:transitionEffect="assignmentLevel" qual:id="tr_csa81_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>csa80</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa375</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>csa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa381</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-844610.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-448678.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa27"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa31" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa27_in_0" /><qual:input qual:qualitativeSpecies="sa138" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa27_in_1" /><qual:input qual:qualitativeSpecies="sa214" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa27_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa27" qual:transitionEffect="assignmentLevel" qual:id="tr_csa27_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><eq /><ci>csa31</ci><cn type="integer">1</cn></apply><apply><and /><apply><eq /><ci>sa138</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa214</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917987.1
+</p>
+<p>https://identifiers.org/reactome:R-HSA-917839.1
+</p>
+<p>https://identifiers.org/reactome:R-HSA-917888.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa29"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa27" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa29_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa29" qual:transitionEffect="assignmentLevel" qual:id="tr_csa29_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa27</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917807.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa30"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa29" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa30_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa30" qual:transitionEffect="assignmentLevel" qual:id="tr_csa30_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa29</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917835.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa31"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa30" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa31_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa31" qual:transitionEffect="assignmentLevel" qual:id="tr_csa31_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa30</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917814.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa32"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa10" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa32_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa32" qual:transitionEffect="assignmentLevel" qual:id="tr_csa32_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa10</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_csa80"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa79" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa80_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa80" qual:transitionEffect="assignmentLevel" qual:id="tr_csa80_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa79</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1296421.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa72"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa495" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_0" /><qual:input qual:qualitativeSpecies="csa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_1" /><qual:input qual:qualitativeSpecies="sa494" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_2" /><qual:input qual:qualitativeSpecies="sa362" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_3" /><qual:input qual:qualitativeSpecies="csa74" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_4" /><qual:input qual:qualitativeSpecies="sa471" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_5" /><qual:input qual:qualitativeSpecies="sa469" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_6" /><qual:input qual:qualitativeSpecies="sa524" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa72_in_7" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa72" qual:transitionEffect="assignmentLevel" qual:id="tr_csa72_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa495</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa72</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa494</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa72</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><or /><apply><eq /><ci>csa74</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa471</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa469</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa524</ci><cn type="integer">1</cn></apply></apply><apply><eq /><ci>sa362</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-873951.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-874087.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-844440.2
+</p>
+<p>
+https://identifiers.org/reactome:R-HSA-1306876.2
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re177">
+<bqbiol:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:29789363" />
+</rdf:Bag>
+</bqbiol:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:26331680" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_csa69"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa363" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa69_in_0" /><qual:input qual:qualitativeSpecies="sa364" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa69_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa69" qual:transitionEffect="assignmentLevel" qual:id="tr_csa69_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa363</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa364</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1250264.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa21"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa150" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa21_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa21" qual:transitionEffect="assignmentLevel" qual:id="tr_csa21_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa150</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_csa79"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa494" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa79_in_0" /><qual:input qual:qualitativeSpecies="csa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa79_in_1" /><qual:input qual:qualitativeSpecies="sa495" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa79_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa79" qual:transitionEffect="assignmentLevel" qual:id="tr_csa79_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa494</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa72</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa495</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa72</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>
+https://identifiers.org/reactome:R-HSA-1306876.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-844440.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa74"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa362" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa74_in_0" /><qual:input qual:qualitativeSpecies="sa363" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa74_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa74" qual:transitionEffect="assignmentLevel" qual:id="tr_csa74_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa362</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa363</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1250272.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa83"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa85" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa83_in_0" /><qual:input qual:qualitativeSpecies="sa377" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa83_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa83" qual:transitionEffect="assignmentLevel" qual:id="tr_csa83_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa85</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa377</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>
+https://identifiers.org/reactome:R-HSA-879221.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa89"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa86" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa89_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa89" qual:transitionEffect="assignmentLevel" qual:id="tr_csa89_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa86</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-874079.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa87"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa89" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa87_in_0" /><qual:input qual:qualitativeSpecies="sa375" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa87_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa87" qual:transitionEffect="assignmentLevel" qual:id="tr_csa87_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa89</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa375</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-844620.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa86"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa378" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa86_in_0" /><qual:input qual:qualitativeSpecies="sa379" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa86_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa86" qual:transitionEffect="assignmentLevel" qual:id="tr_csa86_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa378</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa379</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-844619.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa88"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa375" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa88_in_0" /><qual:input qual:qualitativeSpecies="csa85" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa88_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa88" qual:transitionEffect="assignmentLevel" qual:id="tr_csa88_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa375</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa85</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-877361.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa90"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa87" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa90_in_0" /><qual:input qual:qualitativeSpecies="sa376" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa90_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa90" qual:transitionEffect="assignmentLevel" qual:id="tr_csa90_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa87</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa376</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-844618.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa11"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa144" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa11_in_0" /><qual:input qual:qualitativeSpecies="sa145" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa11_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa11" qual:transitionEffect="assignmentLevel" qual:id="tr_csa11_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><eq /><ci>sa144</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa145</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_csa3"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa32" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa3_in_0" /><qual:input qual:qualitativeSpecies="sa39" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa3_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa3" qual:transitionEffect="assignmentLevel" qual:id="tr_csa3_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa32</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa39</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-9661432.1
+</p>
+<p>https://identifiers.org/reactome:R-HSA-9661405.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa93"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa94" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa93_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa93" qual:transitionEffect="assignmentLevel" qual:id="tr_csa93_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa94</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448702.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_csa94"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa78" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa94_in_0" /><qual:input qual:qualitativeSpecies="sa381" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_csa94_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="csa94" qual:transitionEffect="assignmentLevel" qual:id="tr_csa94_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>csa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa381</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>csa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa381</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>
+https://identifiers.org/reactome:R-HSA-448673.1
+</p>
+<p>https://identifiers.org/reactome:R-HSA-448678.3
+</p>
+<p>https://identifiers.org/reactome:R-HSA-448678.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa21"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa23" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa21_in_0" /><qual:input qual:qualitativeSpecies="sa30" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa21_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa21" qual:transitionEffect="assignmentLevel" qual:id="tr_sa21_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa23</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa30</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-9661408.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa22"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa22_in_0" /><qual:input qual:qualitativeSpecies="sa24" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa22_in_1" /><qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa22_in_2" /><qual:input qual:qualitativeSpecies="sa168" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa22_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa22" qual:transitionEffect="assignmentLevel" qual:id="tr_sa22_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa24</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa25</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa168</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189398.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa23"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa54" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa23_in_0" /><qual:input qual:qualitativeSpecies="sa55" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa23_in_1" /><qual:input qual:qualitativeSpecies="sa53" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa23_in_2" /><qual:input qual:qualitativeSpecies="sa56" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa23_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa23" qual:transitionEffect="assignmentLevel" qual:id="tr_sa23_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa54</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa55</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa53</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa56</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189465.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa26"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa26_in_0" /><qual:input qual:qualitativeSpecies="sa24" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa26_in_1" /><qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa26_in_2" /><qual:input qual:qualitativeSpecies="sa168" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa26_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa26" qual:transitionEffect="assignmentLevel" qual:id="tr_sa26_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa24</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa25</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa168</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189398.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa27"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa27_in_0" /><qual:input qual:qualitativeSpecies="sa24" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa27_in_1" /><qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa27_in_2" /><qual:input qual:qualitativeSpecies="sa168" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa27_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa27" qual:transitionEffect="assignmentLevel" qual:id="tr_sa27_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa24</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa25</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa168</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189398.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa28"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_0" /><qual:input qual:qualitativeSpecies="sa24" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_1" /><qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_2" /><qual:input qual:qualitativeSpecies="sa168" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_3" /><qual:input qual:qualitativeSpecies="sa162" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_4" /><qual:input qual:qualitativeSpecies="sa164" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_5" /><qual:input qual:qualitativeSpecies="sa240" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa28_in_6" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa28" qual:transitionEffect="assignmentLevel" qual:id="tr_sa28_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa24</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa25</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa168</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa162</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa164</ci><cn type="integer">1</cn></apply></apply><apply><eq /><ci>sa240</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189398.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-435349.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa29"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa50" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa29_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa29" qual:transitionEffect="assignmentLevel" qual:id="tr_sa29_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa50</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_sa31"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_0" /><qual:input qual:qualitativeSpecies="sa24" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_1" /><qual:input qual:qualitativeSpecies="sa25" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_2" /><qual:input qual:qualitativeSpecies="sa168" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa31_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa31" qual:transitionEffect="assignmentLevel" qual:id="tr_sa31_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa24</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa25</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa168</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189398.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa32"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa22" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa32_in_0" /><qual:input qual:qualitativeSpecies="sa33" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa32_in_1" /><qual:input qual:qualitativeSpecies="sa36" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa32_in_2" /><qual:input qual:qualitativeSpecies="csa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa32_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa32" qual:transitionEffect="assignmentLevel" qual:id="tr_sa32_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><or /><apply><eq /><ci>sa36</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa21</ci><cn type="integer">1</cn></apply></apply><apply><eq /><ci>sa22</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa33</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189384.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa34"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa22" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa34_in_0" /><qual:input qual:qualitativeSpecies="sa33" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa34_in_1" /><qual:input qual:qualitativeSpecies="sa36" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa34_in_2" /><qual:input qual:qualitativeSpecies="csa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa34_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa34" qual:transitionEffect="assignmentLevel" qual:id="tr_sa34_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><or /><apply><eq /><ci>sa36</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa21</ci><cn type="integer">1</cn></apply></apply><apply><eq /><ci>sa22</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa33</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189384.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa36"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa151" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa36_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa36" qual:transitionEffect="assignmentLevel" qual:id="tr_sa36_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa151</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_sa39"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa171" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa39_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa39" qual:transitionEffect="assignmentLevel" qual:id="tr_sa39_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa171</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re90">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:doi:10.1101%2F2020.03.22.002386" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:taxonomy:2697049" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa43"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa3" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa43_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa43" qual:transitionEffect="assignmentLevel" qual:id="tr_sa43_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa3</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re51">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:12198130" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa44"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa48" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa44_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa44" qual:transitionEffect="assignmentLevel" qual:id="tr_sa44_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa48</ci><cn type="integer">0</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re24">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:28082120" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:21982894" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa50"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa2" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa50_in_0" /><qual:input qual:qualitativeSpecies="csa4" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa50_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa50" qual:transitionEffect="assignmentLevel" qual:id="tr_sa50_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa2</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa4</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re25">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:10473555" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31827672" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:29717933" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa53"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa147" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa53_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa53" qual:transitionEffect="assignmentLevel" qual:id="tr_sa53_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa147</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_sa54"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa117" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa54_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa54" qual:transitionEffect="assignmentLevel" qual:id="tr_sa54_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa117</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189457.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa57"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa54" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa57_in_0" /><qual:input qual:qualitativeSpecies="sa55" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa57_in_1" /><qual:input qual:qualitativeSpecies="sa53" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa57_in_2" /><qual:input qual:qualitativeSpecies="sa56" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa57_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa57" qual:transitionEffect="assignmentLevel" qual:id="tr_sa57_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa54</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa55</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa53</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa56</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189465.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa69"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa65" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa69_in_0" /><qual:input qual:qualitativeSpecies="sa68" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa69_in_1" /><qual:input qual:qualitativeSpecies="sa67" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa69_in_2" /><qual:input qual:qualitativeSpecies="csa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa69_in_3" /><qual:input qual:qualitativeSpecies="sa23" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa69_in_4" /><qual:input qual:qualitativeSpecies="sa20" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa69_in_5" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa69" qual:transitionEffect="assignmentLevel" qual:id="tr_sa69_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa65</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa68</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa67</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa5</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa23</ci><cn type="integer">0</cn></apply><apply><eq /><ci>sa20</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189442.3
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re32">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:25446301" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa70"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa65" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa70_in_0" /><qual:input qual:qualitativeSpecies="sa68" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa70_in_1" /><qual:input qual:qualitativeSpecies="sa67" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa70_in_2" /><qual:input qual:qualitativeSpecies="csa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa70_in_3" /><qual:input qual:qualitativeSpecies="sa23" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa70_in_4" /><qual:input qual:qualitativeSpecies="sa20" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa70_in_5" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa70" qual:transitionEffect="assignmentLevel" qual:id="tr_sa70_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa65</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa68</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa67</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa5</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa23</ci><cn type="integer">0</cn></apply><apply><eq /><ci>sa20</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189442.3
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re32">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:25446301" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa71"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa65" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa71_in_0" /><qual:input qual:qualitativeSpecies="sa68" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa71_in_1" /><qual:input qual:qualitativeSpecies="sa67" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa71_in_2" /><qual:input qual:qualitativeSpecies="csa5" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa71_in_3" /><qual:input qual:qualitativeSpecies="sa23" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa71_in_4" /><qual:input qual:qualitativeSpecies="sa20" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa71_in_5" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa71" qual:transitionEffect="assignmentLevel" qual:id="tr_sa71_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa65</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa68</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa67</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa5</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa23</ci><cn type="integer">0</cn></apply><apply><eq /><ci>sa20</ci><cn type="integer">0</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189442.3
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re32">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:25446301" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa72"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa69" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa72_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa72" qual:transitionEffect="assignmentLevel" qual:id="tr_sa72_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa69</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189456.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa101"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa101_in_0" /><qual:input qual:qualitativeSpecies="csa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa101_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa101" qual:transitionEffect="assignmentLevel" qual:id="tr_sa101_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa72</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa14</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189439.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa103"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa103_in_0" /><qual:input qual:qualitativeSpecies="csa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa103_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa103" qual:transitionEffect="assignmentLevel" qual:id="tr_sa103_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa72</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa14</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189439.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa104"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa72" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa104_in_0" /><qual:input qual:qualitativeSpecies="csa14" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa104_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa104" qual:transitionEffect="assignmentLevel" qual:id="tr_sa104_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa72</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa14</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189439.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa105"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa101" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa105_in_0" /><qual:input qual:qualitativeSpecies="sa106" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa105_in_1" /><qual:input qual:qualitativeSpecies="csa15" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa105_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa105" qual:transitionEffect="assignmentLevel" qual:id="tr_sa105_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa101</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa106</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa15</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189406.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa107"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa101" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa107_in_0" /><qual:input qual:qualitativeSpecies="sa106" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa107_in_1" /><qual:input qual:qualitativeSpecies="csa15" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa107_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa107" qual:transitionEffect="assignmentLevel" qual:id="tr_sa107_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa101</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa106</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa15</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189406.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa111"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa105" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa111_in_0" /><qual:input qual:qualitativeSpecies="sa112" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa111_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa111" qual:transitionEffect="assignmentLevel" qual:id="tr_sa111_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa105</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa112</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189488.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa113"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa111" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa113_in_0" /><qual:input qual:qualitativeSpecies="sa114" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa113_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa113" qual:transitionEffect="assignmentLevel" qual:id="tr_sa113_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa111</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa114</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189425.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa115"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa113" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa115_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa115" qual:transitionEffect="assignmentLevel" qual:id="tr_sa115_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa113</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189467.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa116"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa115" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa116_in_0" /><qual:input qual:qualitativeSpecies="sa121" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa116_in_1" /><qual:input qual:qualitativeSpecies="sa118" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa116_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa116" qual:transitionEffect="assignmentLevel" qual:id="tr_sa116_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa115</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa121</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa118</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189421.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa117"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa116" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa117_in_0" /><qual:input qual:qualitativeSpecies="sa124" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa117_in_1" /><qual:input qual:qualitativeSpecies="csa17" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa117_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa117" qual:transitionEffect="assignmentLevel" qual:id="tr_sa117_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa116</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa124</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa17</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189423.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa122"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa115" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa122_in_0" /><qual:input qual:qualitativeSpecies="sa121" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa122_in_1" /><qual:input qual:qualitativeSpecies="sa118" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa122_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa122" qual:transitionEffect="assignmentLevel" qual:id="tr_sa122_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa115</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa121</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa118</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189421.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa123"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa115" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa123_in_0" /><qual:input qual:qualitativeSpecies="sa121" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa123_in_1" /><qual:input qual:qualitativeSpecies="sa118" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa123_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa123" qual:transitionEffect="assignmentLevel" qual:id="tr_sa123_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa115</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa121</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa118</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189421.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa125"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa116" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa125_in_0" /><qual:input qual:qualitativeSpecies="sa124" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa125_in_1" /><qual:input qual:qualitativeSpecies="csa17" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa125_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa125" qual:transitionEffect="assignmentLevel" qual:id="tr_sa125_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa116</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa124</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa17</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-189423.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa127"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa130" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa127_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa127" qual:transitionEffect="assignmentLevel" qual:id="tr_sa127_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa130</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re89">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:26794443" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa130"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa128" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa130_in_0" /><qual:input qual:qualitativeSpecies="sa165" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa130_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa130" qual:transitionEffect="assignmentLevel" qual:id="tr_sa130_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa128</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa165</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re59">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:26794443" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa135"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa28" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa135_in_0" /><qual:input qual:qualitativeSpecies="csa12" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa135_in_1" /><qual:input qual:qualitativeSpecies="csa22" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa135_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa135" qual:transitionEffect="assignmentLevel" qual:id="tr_sa135_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa28</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa12</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa28</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa22</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-904830.1
+</p>
+<p>https://identifiers.org/reactome:R-HSA-442368.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa138"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa135" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_0" /><qual:input qual:qualitativeSpecies="sa156" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_1" /><qual:input qual:qualitativeSpecies="sa157" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_2" /><qual:input qual:qualitativeSpecies="csa12" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_3" /><qual:input qual:qualitativeSpecies="sa212" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_4" /><qual:input qual:qualitativeSpecies="sa213" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_5" /><qual:input qual:qualitativeSpecies="csa22" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa138_in_6" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa138" qual:transitionEffect="assignmentLevel" qual:id="tr_sa138_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa135</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa156</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa157</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa12</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa135</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa212</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa213</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa22</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917891.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-917933.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa140"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa140_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa140" qual:transitionEffect="assignmentLevel" qual:id="tr_sa140_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>PMID: 21303654
+PMID: 30692038
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re63">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa144"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa144_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa144" qual:transitionEffect="assignmentLevel" qual:id="tr_sa144_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re65">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa145"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa145_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa145" qual:transitionEffect="assignmentLevel" qual:id="tr_sa145_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re66">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa147"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa147_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa147" qual:transitionEffect="assignmentLevel" qual:id="tr_sa147_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re69">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:23766848" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa150"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa150_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa150" qual:transitionEffect="assignmentLevel" qual:id="tr_sa150_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re72">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa151"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa43" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa151_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa151" qual:transitionEffect="assignmentLevel" qual:id="tr_sa151_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa43</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re73">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa152"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa28" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa152_in_0" /><qual:input qual:qualitativeSpecies="sa136" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa152_in_1" /><qual:input qual:qualitativeSpecies="sa137" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa152_in_2" /><qual:input qual:qualitativeSpecies="csa11" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa152_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa152" qual:transitionEffect="assignmentLevel" qual:id="tr_sa152_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa28</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa136</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa137</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa11</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1562626.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa158"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa135" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa158_in_0" /><qual:input qual:qualitativeSpecies="sa156" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa158_in_1" /><qual:input qual:qualitativeSpecies="sa157" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa158_in_2" /><qual:input qual:qualitativeSpecies="csa12" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa158_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa158" qual:transitionEffect="assignmentLevel" qual:id="tr_sa158_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa135</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa156</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa157</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa12</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917891.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa162"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa138" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa162_in_0" /><qual:input qual:qualitativeSpecies="sa195" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa162_in_1" /><qual:input qual:qualitativeSpecies="csa13" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa162_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa162" qual:transitionEffect="assignmentLevel" qual:id="tr_sa162_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa138</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa195</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa13</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917805.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa165"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa28" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa165_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa165" qual:transitionEffect="assignmentLevel" qual:id="tr_sa165_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa28</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re88">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:26794443" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa166"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa130" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa166_in_0" /><qual:input qual:qualitativeSpecies="sa167" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa166_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa166" qual:transitionEffect="assignmentLevel" qual:id="tr_sa166_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa130</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa167</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re85">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:26794443" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:30692038" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa168"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa29" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa168_in_0" /><qual:input qual:qualitativeSpecies="sa169" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa168_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa168" qual:transitionEffect="assignmentLevel" qual:id="tr_sa168_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa29</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa169</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>Could not find this site in identifiers.org. This interaction is described in the Gordon et.al. preprint.
+https://www.biorxiv.org/content/10.1101/2020.03.22.002386v3
+</p>
+</body></html></notes><annotation><rdf:RDF><rdf:Description rdf:about="#re87">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:doi:10.1101%2F2020.03.22.002386" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqbiol:isEncodedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:taxonomy:2697049" />
+</rdf:Bag>
+</bqbiol:isEncodedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa3"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa6" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa3_in_0" /><qual:input qual:qualitativeSpecies="sa190" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa3_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa3" qual:transitionEffect="assignmentLevel" qual:id="tr_sa3_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa6</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa190</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re96">
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:31692987" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+<bqmodel:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:12198130" />
+</rdf:Bag>
+</bqmodel:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition><qual:transition qual:id="tr_sa197"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa197_in_0" /><qual:input qual:qualitativeSpecies="sa196" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa197_in_1" /><qual:input qual:qualitativeSpecies="sa206" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa197_in_2" /><qual:input qual:qualitativeSpecies="sa203" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa197_in_3" /><qual:input qual:qualitativeSpecies="sa198" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa197_in_4" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa197" qual:transitionEffect="assignmentLevel" qual:id="tr_sa197_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa196</ci><cn type="integer">1</cn></apply></apply><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa206</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa203</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa198</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917892.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-917979.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa204"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa204_in_0" /><qual:input qual:qualitativeSpecies="sa206" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa204_in_1" /><qual:input qual:qualitativeSpecies="sa203" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa204_in_2" /><qual:input qual:qualitativeSpecies="sa198" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa204_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa204" qual:transitionEffect="assignmentLevel" qual:id="tr_sa204_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa206</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa203</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa198</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917979.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa205"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa21" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa205_in_0" /><qual:input qual:qualitativeSpecies="sa206" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa205_in_1" /><qual:input qual:qualitativeSpecies="sa203" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa205_in_2" /><qual:input qual:qualitativeSpecies="sa198" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa205_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa205" qual:transitionEffect="assignmentLevel" qual:id="tr_sa205_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa21</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa206</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa203</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa198</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917979.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa211"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa135" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa211_in_0" /><qual:input qual:qualitativeSpecies="sa212" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa211_in_1" /><qual:input qual:qualitativeSpecies="sa213" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa211_in_2" /><qual:input qual:qualitativeSpecies="csa22" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa211_in_3" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa211" qual:transitionEffect="assignmentLevel" qual:id="tr_sa211_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa135</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa212</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa213</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa22</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917933.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa214"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa31" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa214_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa214" qual:transitionEffect="assignmentLevel" qual:id="tr_sa214_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa31</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917839.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa229"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa29" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa229_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa229" qual:transitionEffect="assignmentLevel" qual:id="tr_sa229_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa29</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917835.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa238"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa229" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa238_in_0" /><qual:input qual:qualitativeSpecies="sa242" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa238_in_1" /><qual:input qual:qualitativeSpecies="sa243" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa238_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa238" qual:transitionEffect="assignmentLevel" qual:id="tr_sa238_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa229</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa242</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa243</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917811.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa240"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa238" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa240_in_0" /><qual:input qual:qualitativeSpecies="sa241" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa240_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa240" qual:transitionEffect="assignmentLevel" qual:id="tr_sa240_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa238</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa241</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-917936.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa249"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa10" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa249_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa249" qual:transitionEffect="assignmentLevel" qual:id="tr_sa249_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa10</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms></qual:transition><qual:transition qual:id="tr_sa362"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa367" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa362_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa362" qual:transitionEffect="assignmentLevel" qual:id="tr_sa362_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa367</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-9603905.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa363"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa68" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa363_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa363" qual:transitionEffect="assignmentLevel" qual:id="tr_sa363_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa68</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1250253.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa366"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa68" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa366_in_0" /><qual:input qual:qualitativeSpecies="sa364" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa366_in_1" /><qual:input qual:qualitativeSpecies="sa493" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa366_in_2" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa366" qual:transitionEffect="assignmentLevel" qual:id="tr_sa366_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><or /><apply><eq /><ci>csa68</ci><cn type="integer">1</cn></apply><apply><and /><apply><eq /><ci>sa364</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa493</ci><cn type="integer">1</cn></apply></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-1250253.2
+</p>
+<p>https://identifiers.org/reactome:R-HSA-1250280.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa367"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa101" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa367_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa367" qual:transitionEffect="assignmentLevel" qual:id="tr_sa367_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>csa101</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-9603905.2
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa382"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa78" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa382_in_0" /><qual:input qual:qualitativeSpecies="sa381" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa382_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa382" qual:transitionEffect="assignmentLevel" qual:id="tr_sa382_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa381</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448678.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa385"><qual:listOfInputs><qual:input qual:qualitativeSpecies="csa78" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa385_in_0" /><qual:input qual:qualitativeSpecies="sa381" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa385_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa385" qual:transitionEffect="assignmentLevel" qual:id="tr_sa385_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>csa78</ci><cn type="integer">1</cn></apply><apply><eq /><ci>sa381</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448678.3
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa460"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa462" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa460_in_0" /><qual:input qual:qualitativeSpecies="csa93" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa460_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa460" qual:transitionEffect="assignmentLevel" qual:id="tr_sa460_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa462</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa93</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448703.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa461"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa463" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa461_in_0" /><qual:input qual:qualitativeSpecies="csa93" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa461_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa461" qual:transitionEffect="assignmentLevel" qual:id="tr_sa461_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa463</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa93</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448703.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa464"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa462" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa464_in_0" /><qual:input qual:qualitativeSpecies="csa93" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa464_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa464" qual:transitionEffect="assignmentLevel" qual:id="tr_sa464_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa462</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa93</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448703.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa465"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa463" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa465_in_0" /><qual:input qual:qualitativeSpecies="csa93" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa465_in_1" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa465" qual:transitionEffect="assignmentLevel" qual:id="tr_sa465_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><and /><apply><eq /><ci>sa463</ci><cn type="integer">1</cn></apply><apply><eq /><ci>csa93</ci><cn type="integer">1</cn></apply></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-448703.4
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa466"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa464" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa466_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa466" qual:transitionEffect="assignmentLevel" qual:id="tr_sa466_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa464</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-449058.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa467"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa465" qual:transitionEffect="none" qual:sign="positive" qual:id="tr_sa467_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa467" qual:transitionEffect="assignmentLevel" qual:id="tr_sa467_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa465</ci><cn type="integer">1</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><notes><html xmlns="http://www.w3.org/1999/xhtml"><head><title /></head><body><p>https://identifiers.org/reactome:R-HSA-449058.1
+</p>
+</body></html></notes></qual:transition><qual:transition qual:id="tr_sa524"><qual:listOfInputs><qual:input qual:qualitativeSpecies="sa31" qual:transitionEffect="none" qual:sign="negative" qual:id="tr_sa524_in_0" /></qual:listOfInputs><qual:listOfOutputs><qual:output qual:qualitativeSpecies="sa524" qual:transitionEffect="assignmentLevel" qual:id="tr_sa524_out" /></qual:listOfOutputs><qual:listOfFunctionTerms><qual:defaultTerm qual:resultLevel="0" /><qual:functionTerm qual:resultLevel="1"><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><eq /><ci>sa31</ci><cn type="integer">0</cn></apply></math></qual:functionTerm></qual:listOfFunctionTerms><annotation><rdf:RDF><rdf:Description rdf:about="#re182">
+<bqbiol:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:28356568" />
+</rdf:Bag>
+</bqbiol:isDescribedBy>
+<bqbiol:isDescribedBy>
+<rdf:Bag>
+<rdf:li rdf:resource="urn:miriam:pubmed:25770182" />
+</rdf:Bag>
+</bqbiol:isDescribedBy>
+</rdf:Description>
+</rdf:RDF></annotation></qual:transition></qual:listOfTransitions></model></sbml>

--- a/src/sbml/mod.rs
+++ b/src/sbml/mod.rs
@@ -928,4 +928,13 @@ mod tests {
         let (actual, layout) = BooleanNetwork::from_sbml(model.as_str()).unwrap();
         assert_eq!(layout.len(), actual.graph.num_vars());
     }
+
+    #[test]
+    fn test_apoptosis_network() {
+        let model = std::fs::read_to_string("sbml_models/apoptosis_network.sbml")
+            .expect("Cannot open result file.");
+        let (actual, layout) = BooleanNetwork::from_sbml(model.as_str()).unwrap();
+        assert_eq!(actual.graph.num_vars(), 41);
+        assert_eq!(layout.len(), 0);
+    }
 }

--- a/src/sbml/mod.rs
+++ b/src/sbml/mod.rs
@@ -71,6 +71,31 @@ fn rename_fn_variables(species: &Vec<(String, String)>, fun: FnUpdateTemp) -> Fn
     };
 }
 
+fn resolve_name_clashes(species: &mut Vec<(String, String)>) {
+    // Sadly, some models don't use unique specie names, only unique species IDs.
+    // If we want to preserve names, we thus have to make them unique...
+    // We only change the names that actually clash so that the changes to the model are minimal...
+    let mut unique_names: HashSet<String> = HashSet::new();
+    let mut duplicates: HashSet<String> = HashSet::new();
+    for (_, name) in species.iter() {
+        if unique_names.contains(name) {
+            duplicates.insert(name.clone());
+        } else {
+            unique_names.insert(name.clone());
+        }
+    }
+    for (id, name) in species.iter_mut() {
+        if duplicates.contains(name) {
+            let normalized = format!("{}_{}", id, name);
+            println!(
+                "WARNING: Renaming duplicate `{}` to `{}`.",
+                name, normalized
+            );
+            *name = normalized;
+        }
+    }
+}
+
 // Read a network and an associated layout!
 fn read_model(parser: &mut EventReader<&[u8]>) -> Result<(BooleanNetwork, Layout), String> {
     let mut in_model = false;
@@ -83,6 +108,7 @@ fn read_model(parser: &mut EventReader<&[u8]>) -> Result<(BooleanNetwork, Layout
             XmlEvent::EndElement { name } => {
                 if name.local_name.as_str() == "model" {
                     species.sort_by_key(|(_, name)| name.clone());
+                    resolve_name_clashes(&mut species);
                     // Remap transitions to use specie names instead of IDs.
                     for t in transitions.iter_mut() {
                         t.target = resolve_specie(&species, &t.target).to_string();
@@ -228,7 +254,7 @@ fn normalize_name(name: String) -> String {
     let name_regex = Regex::new(r"[^a-zA-Z0-9_]").unwrap();
     let normalized = name_regex.replace_all(&name, "_").to_string();
     if normalized != name {
-        println!("WARNING: Renaming `{}` to `{}`.", name, normalized);
+        println!("WARNING: Renaming invalid `{}` to `{}`.", name, normalized);
     }
     return normalized;
 }
@@ -268,9 +294,9 @@ fn read_species(
                         if name.is_empty() {
                             name = id.clone();
                         }
-                        // Check that species is unique.
-                        for (existing_id, existing_name) in species.iter() {
-                            if existing_name == &name || existing_id == &id {
+                        // Check that species is unique (names don't have to be unique - yet...)
+                        for (existing_id, _) in species.iter() {
+                            if existing_id == &id {
                                 return Err(format!("Duplicate species {}.", name));
                             }
                         }
@@ -851,5 +877,21 @@ mod tests {
                 .monotonicity,
             Some(Monotonicity::Activation)
         )
+    }
+
+    #[test]
+    fn test_apoptosis_stable() {
+        // Has colliding names/ids
+        let model = std::fs::read_to_string("sbml_models/apoptosis_stable.sbml")
+            .expect("Cannot open result file.");
+        let (actual, layout) = BooleanNetwork::from_sbml(model.as_str()).unwrap();
+        assert_eq!(layout.len(), actual.graph.num_vars());
+        // Normal variable
+        assert!(actual.graph.find_variable("Apoptosome_complex").is_some());
+        // Normalized variable
+        assert!(actual.graph.find_variable("FAS_FASL_complex").is_some());
+        // Duplicate name
+        assert!(actual.graph.find_variable("sa19_CASP9_Cytoplasm").is_some());
+        assert!(actual.graph.find_variable("sa47_CASP9_Cytoplasm").is_some());
     }
 }

--- a/src/sbml/mod.rs
+++ b/src/sbml/mod.rs
@@ -42,6 +42,9 @@ impl BooleanNetwork {
                 _ => {}
             }
         }
+        if let Some(error) = parser.next().err() {
+            return Err(error.to_string());
+        }
         return Err("Expected </sbml>, but found end of XML document.".to_string());
     }
 }
@@ -186,6 +189,9 @@ fn read_model(parser: &mut EventReader<&[u8]>) -> Result<(BooleanNetwork, Layout
             _ => {}
         }
     }
+    if let Some(error) = parser.next().err() {
+        return Err(error.to_string());
+    }
     return Err("Expected </model>, but found end of XML document.".to_string());
 }
 
@@ -246,6 +252,9 @@ fn read_layout(
             }
             _ => {}
         }
+    }
+    if let Some(error) = parser.next().err() {
+        return Err(error.to_string());
     }
     return Err("Expected </layout:layout>, but found end of XML document.".to_string());
 }
@@ -311,6 +320,9 @@ fn read_species(
             }
             _ => {}
         }
+    }
+    if let Some(error) = parser.next().err() {
+        return Err(error.to_string());
     }
     return Err(
         "Expected </qual:listOfQualitativeSpecies>, but found end of XML document.".to_string(),
@@ -393,6 +405,9 @@ fn read_transitions(
             }
             _ => {}
         }
+    }
+    if let Some(error) = parser.next().err() {
+        return Err(error.to_string());
     }
     return Err("Expected </qual:listOfTransitions>, but found end of XML document.".to_string());
 }
@@ -742,6 +757,9 @@ fn read_update_function(parser: &mut EventReader<&[u8]>) -> Result<FnUpdateTemp,
             }
             _ => {}
         }
+    }
+    if let Some(error) = parser.next().err() {
+        return Err(error.to_string());
     }
     return Err("Expected </qual:listOfFunctionTerms> but found end of document.".to_string());
 }


### PR DESCRIPTION
This PR extends #7 and resolves several new problems discovered when using the SBML parser.

 1. In some models, there are several entities that share the same name, but have different id. After #7 was merged, these models could not be imported due to the name clash. Here, we fix this problem by detecting such duplicate names and prefixing such name with its id, which is always unique. Names that do not clash are unchanged.
 2. Models that work with DNF/CNF representations of boolean functions tend to also include `and/or` tags with only one argument. This previously caused an error, but now these useless tags are simply ignored.
 3. When reading lists of XML tags, any discovered syntax error would be silently dropped and replaced with an error about unexpected end of document. We try to mitigate this and return the syntax error instead where possible.
 4. Sadly, `xml-rs` contains a [bug](https://github.com/netvl/xml-rs/issues/197) that considers strings with value `/>` to be invalid. Such strings appear in SBML models when HTML formatting is included in annotations/notes. Thankfully, a [pull request](https://github.com/netvl/xml-rs/pull/195) for this issue exists, but is not released yet. So for the time being, we switch to the fork where the bug is already fixed. Once the issue is resolved, we can move back to depending on `xml-rs`.

Overall, this pull request closes all major issues with SBML parsing that I am aware of (So far, I haven't found any problematic SBML model in ginsim/cellcollective databases). It is therefore related to #1, however, I still don't believe the issue should be closed because: a) I am expecting further problems as more models are tested, the issue will track those. b) The SBML parser is still a poorly designed and poorly tested heap of garbage. We really need a better way to handle it. However, it will probably also require minor changes to the `.aeon` text format.