### PR TITLE
Remove biodivine-lib-std references from the project.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ regex = "1.3.3"     # used when parsing text format
 # have to use this for which actually fixes it.
 xml-rs = { git="https://github.com/jdalberg/xml-rs.git", branch="parsefix" }
 biodivine-lib-bdd = "0.1.0"
-biodivine-lib-std = { git = "https://github.com/sybila/biodivine-lib-std.git" }
 
 [features]
 # With shields_up you enable explicit assertions of pre/post conditions and invariants in critical

--- a/src/async_graph/impl_default_edge_params.rs
+++ b/src/async_graph/impl_default_edge_params.rs
@@ -1,8 +1,8 @@
 use crate::async_graph::{AsyncGraphEdgeParams, DefaultEdgeParams};
 use crate::bdd_params::{build_static_constraints, BddParameterEncoder, BddParams};
+use crate::biodivine_std::structs::IdState;
+use crate::biodivine_std::traits::Params;
 use crate::{BooleanNetwork, VariableId};
-use biodivine_lib_std::param_graph::Params;
-use biodivine_lib_std::IdState;
 
 impl DefaultEdgeParams {
     /// New default edge parametrisation for the given network. Warning: computes the unit set, which can be expensive.

--- a/src/async_graph/impl_evolution_operators.rs
+++ b/src/async_graph/impl_evolution_operators.rs
@@ -1,6 +1,6 @@
 use crate::async_graph::{AsyncGraphEdgeParams, Bwd, BwdIterator, Fwd, FwdIterator};
-use biodivine_lib_std::param_graph::{EvolutionOperator, InvertibleEvolutionOperator};
-use biodivine_lib_std::IdState;
+use crate::biodivine_std::structs::IdState;
+use crate::biodivine_std::traits::{EvolutionOperator, InvertibleEvolutionOperator};
 
 impl<'a, Params: AsyncGraphEdgeParams> EvolutionOperator for Fwd<'a, Params> {
     type State = IdState;
@@ -78,9 +78,9 @@ impl<Params: AsyncGraphEdgeParams> Iterator for BwdIterator<'_, Params> {
 mod tests {
     use crate::async_graph::AsyncGraph;
     use crate::bdd_params::BddParams;
+    use crate::biodivine_std::structs::IdState;
+    use crate::biodivine_std::traits::{EvolutionOperator, Graph, Params};
     use crate::BooleanNetwork;
-    use biodivine_lib_std::param_graph::{EvolutionOperator, Graph, Params};
-    use biodivine_lib_std::IdState;
     use std::collections::HashSet;
     use std::convert::TryFrom;
 

--- a/src/async_graph/mod.rs
+++ b/src/async_graph/mod.rs
@@ -1,7 +1,7 @@
 use crate::bdd_params::{BddParameterEncoder, BddParams};
+use crate::biodivine_std::structs::{IdState, IdStateRange};
+use crate::biodivine_std::traits::{Graph, InvertibleGraph, Params};
 use crate::{BooleanNetwork, VariableId, VariableIdIterator};
-use biodivine_lib_std::param_graph::{Graph, InvertibleGraph};
-use biodivine_lib_std::{IdState, IdStateRange};
 
 mod impl_async_graph;
 mod impl_default_edge_params;
@@ -41,7 +41,7 @@ pub struct DefaultEdgeParams {
 /// parameter encoders, where we simply do not want to re-implement the whole graph trait
 /// front scratch.
 pub trait AsyncGraphEdgeParams {
-    type ParamSet: biodivine_lib_std::param_graph::Params;
+    type ParamSet: Params;
     // A reference to the underlying Boolean network.
     fn network(&self) -> &BooleanNetwork;
     /// Create a new empty set of parameters.

--- a/src/bdd_params/impl_bdd_parameter_encoder.rs
+++ b/src/bdd_params/impl_bdd_parameter_encoder.rs
@@ -1,8 +1,8 @@
 use super::BddParameterEncoder;
 use crate::bdd_params::{BddParams, FunctionTableEntry};
+use crate::biodivine_std::structs::IdState;
 use crate::{BooleanNetwork, ParameterId, VariableId};
 use biodivine_lib_bdd::{BddValuationIterator, BddVariable, BddVariableSetBuilder};
-use biodivine_lib_std::IdState;
 
 impl BddParameterEncoder {
     /// Create a new `BddParameterEncoder` based on information given in a `BooleanNetwork`.
@@ -161,9 +161,9 @@ impl BddParameterEncoder {
 #[cfg(test)]
 mod tests {
     use crate::bdd_params::BddParameterEncoder;
+    use crate::biodivine_std::structs::IdState;
     use crate::BooleanNetwork;
     use crate::VariableId;
-    use biodivine_lib_std::IdState;
     use std::convert::TryFrom;
 
     #[test]

--- a/src/bdd_params/impl_bdd_params.rs
+++ b/src/bdd_params/impl_bdd_params.rs
@@ -1,6 +1,6 @@
 use super::BddParams;
+use crate::biodivine_std::traits::Params;
 use biodivine_lib_bdd::Bdd;
-use biodivine_lib_std::param_graph::Params;
 
 impl BddParams {
     /// Consume these `BddParams` and turn them into a raw `Bdd`.

--- a/src/bdd_params/impl_fn_update.rs
+++ b/src/bdd_params/impl_fn_update.rs
@@ -1,7 +1,7 @@
 use crate::bdd_params::{BddParameterEncoder, BddParams};
+use crate::biodivine_std::structs::IdState;
 use crate::{BinaryOp, FnUpdate};
 use biodivine_lib_bdd::Bdd;
-use biodivine_lib_std::IdState;
 
 impl FnUpdate {
     /// Evaluate this `FnUpdate` into symbolic `BddParams` that represent all parameter

--- a/src/bdd_params/impl_static_constraints.rs
+++ b/src/bdd_params/impl_static_constraints.rs
@@ -2,9 +2,9 @@
 //! to the static constraints of the individual regulations of a `BooleanNetwork`.
 
 use crate::bdd_params::BddParameterEncoder;
+use crate::biodivine_std::structs::IdState;
 use crate::{BooleanNetwork, FnUpdate, Monotonicity, Regulation, VariableId};
 use biodivine_lib_bdd::{bdd, Bdd};
-use biodivine_lib_std::IdState;
 use std::ops::Range;
 
 /// Build a `Bdd` which describes all valuations satisfying the static constraints

--- a/src/bin/dump_graph.rs
+++ b/src/bin/dump_graph.rs
@@ -1,8 +1,8 @@
 use biodivine_lib_bdd::{BddValuation, BddValuationIterator};
 use biodivine_lib_param_bn::async_graph::AsyncGraph;
 use biodivine_lib_param_bn::bdd_params::BddParameterEncoder;
+use biodivine_lib_param_bn::biodivine_std::traits::{EvolutionOperator, Graph};
 use biodivine_lib_param_bn::BooleanNetwork;
-use biodivine_lib_std::param_graph::{EvolutionOperator, Graph};
 use std::convert::TryFrom;
 use std::io::Read;
 

--- a/src/biodivine_std/mod.rs
+++ b/src/biodivine_std/mod.rs
@@ -1,0 +1,2 @@
+pub mod structs;
+pub mod traits;

--- a/src/biodivine_std/structs.rs
+++ b/src/biodivine_std/structs.rs
@@ -1,0 +1,120 @@
+use crate::biodivine_std::traits::State;
+use std::collections::HashMap;
+/// Basic structs which are carried over from lib-biodivine_std for now.
+///
+/// In the future, these will be replaced by a more stable variants.
+use std::fmt::{Display, Error, Formatter};
+use std::hash::Hash;
+
+/// Build a mapping from elements of the given vector to their respective indices.
+///
+/// **Warning:** Duplicates are not detected or handled in any way, they are just overwritten.
+pub fn build_index_map<T, F, R>(keys: &Vec<T>, transform_index: F) -> HashMap<T, R>
+where
+    F: Fn(&T, usize) -> R,
+    T: Clone + Hash + PartialEq + Eq,
+{
+    let mut result = HashMap::new();
+    for i in 0..keys.len() {
+        let item = &keys[i];
+        result.insert(item.clone(), transform_index(item, i));
+    }
+    return result;
+}
+
+/// A very basic implementation of a `State` which simply stores a single `usize` index.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct IdState(usize);
+
+/// A simple `IdState` iterator used for graphs where the states are consecutive integers.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct IdStateRange {
+    next: usize,
+    remaining: usize,
+}
+
+impl State for IdState {}
+
+impl From<usize> for IdState {
+    fn from(val: usize) -> Self {
+        return IdState(val);
+    }
+}
+
+impl Into<usize> for IdState {
+    fn into(self) -> usize {
+        return self.0;
+    }
+}
+
+impl Display for IdState {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        return write!(f, "State({})", self.0);
+    }
+}
+
+impl IdState {
+    /// Test if the bit at the given position is set or not.
+    pub fn get_bit(self, bit: usize) -> bool {
+        return (self.0 >> bit) & 1 == 1;
+    }
+
+    /// Flip the bit a the given position.
+    pub fn flip_bit(self, bit: usize) -> IdState {
+        return IdState(self.0 ^ (1 << bit));
+    }
+}
+
+impl IdStateRange {
+    pub fn new(state_count: usize) -> IdStateRange {
+        return IdStateRange {
+            next: 0,
+            remaining: state_count,
+        };
+    }
+}
+
+impl Iterator for IdStateRange {
+    type Item = IdState;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        return if self.remaining == 0 {
+            None
+        } else {
+            let result = self.next;
+            self.remaining -= 1;
+            self.next += 1;
+            Some(IdState::from(result))
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::biodivine_std::structs::{IdState, IdStateRange};
+
+    #[test]
+    fn id_state_test() {
+        let state = IdState::from(0b10110);
+        assert!(!state.get_bit(0));
+        assert!(state.get_bit(1));
+        assert!(state.get_bit(2));
+        assert!(!state.get_bit(3));
+        assert!(state.get_bit(4));
+        let flipped = state.flip_bit(3);
+        assert_eq!(0b11110 as usize, flipped.into());
+    }
+
+    #[test]
+    fn test_state_range_iterator() {
+        let mut iter = IdStateRange::new(6);
+        assert_eq!(Some(IdState::from(0)), iter.next());
+        assert_eq!(Some(IdState::from(1)), iter.next());
+        assert_eq!(Some(IdState::from(2)), iter.next());
+        assert_eq!(Some(IdState::from(3)), iter.next());
+        assert_eq!(Some(IdState::from(4)), iter.next());
+        assert_eq!(Some(IdState::from(5)), iter.next());
+        assert_eq!(None, iter.next());
+        assert_eq!(None, iter.next());
+    }
+}

--- a/src/biodivine_std/traits.rs
+++ b/src/biodivine_std/traits.rs
@@ -1,0 +1,76 @@
+/// Basic traits which are carried over from lib-biodivine_std for now.
+///
+/// In the future, these will be replaced by a more stable variants.
+use std::hash::Hash;
+
+/// A marker trait for anything that can be a state of a graph.
+///
+/// Currently, we require each state to be a `Copy` struct, i.e. it has to be
+/// "small enough" so that it can be copied whenever needed. In the future, we might
+/// lift this restriction if the need for more complex states arises. Meanwhile, one
+/// can use dynamically indexed states.
+pub trait State: Hash + Eq + Clone + Copy {}
+
+/// `Params` represents a set of parameter valuations and thus typically behaves like a
+/// normal set.
+///
+/// However, notice that there is no complement method available. This is because the
+/// `unit` set of parameters can be different every time or completely unknown. To
+/// implement complement, use `minus` with an appropriate `unit` set.
+///
+/// Also notice that we do not assume anything about the members of the set, we can't
+/// iterate them or even retrieve them. This is because the sets might be uncountable
+/// or the elements might not be well representable.
+pub trait Params: Clone {
+    fn union(&self, other: &Self) -> Self;
+    fn intersect(&self, other: &Self) -> Self;
+    fn minus(&self, other: &Self) -> Self;
+
+    fn is_empty(&self) -> bool;
+    fn is_subset(&self, other: &Self) -> bool;
+}
+
+/// A parametrised variant of an `EvolutionOperator`. For each state, a `Params` set is
+/// returned as well which gives the set of parameter valuations for which the transition
+/// is allowed.
+pub trait EvolutionOperator {
+    type State: State;
+    type Params: Params;
+    type Iterator: Iterator<Item = (Self::State, Self::Params)>;
+    fn step(&self, current: Self::State) -> Self::Iterator;
+}
+
+/// A variant of the `EvolutionOperator` that can be inverted.
+///
+/// This is useful if you have algorithms that need to follow edges in both directions but have
+/// some "preferred" sense of direction. For example, a model checking algorithm can verify
+/// formulas that mix past and future. It typically starts in "future" mode, but can switch
+/// to "past" depending on the formula. If the operator is invertible, one can just
+/// invert the evolution operator in the algorithm without caring whether we are working on
+/// past or future. In other words, the sense of time is relative.
+///
+/// Technically, this can be also achieved by switching between `fwd` and `bwd` in the algorithm,
+/// but that can be cumbersome because the sense of "direction" becomes diluted. In other words,
+/// it is easy to lose track of what is going on if you see something like `let fwd = bwd;`...
+pub trait InvertibleEvolutionOperator: EvolutionOperator {
+    type InvertedOperator: EvolutionOperator<State = Self::State, Params = Self::Params>;
+    fn invert(&self) -> Self::InvertedOperator;
+}
+
+/// A parametrised variant of a `Graph`.
+pub trait Graph {
+    type State: State;
+    type Params: Params;
+    type States: Iterator<Item = Self::State>;
+    type FwdEdges: EvolutionOperator;
+    type BwdEdges: EvolutionOperator;
+
+    fn states(&self) -> Self::States;
+    fn fwd(&self) -> Self::FwdEdges;
+    fn bwd(&self) -> Self::BwdEdges;
+}
+
+pub trait InvertibleGraph: Graph {
+    type FwdEdges: InvertibleEvolutionOperator;
+    type BwdEdges: InvertibleEvolutionOperator;
+}

--- a/src/impl_regulatory_graph.rs
+++ b/src/impl_regulatory_graph.rs
@@ -1,6 +1,6 @@
 use super::{Regulation, RegulatoryGraph, Variable, VariableId};
+use crate::biodivine_std::structs::build_index_map;
 use crate::{Monotonicity, VariableIdIterator};
-use biodivine_lib_std::util::build_index_map;
 
 /// Methods for safely constructing new instances of `RegulatoryGraph`s.
 impl RegulatoryGraph {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 
 pub mod async_graph;
 pub mod bdd_params;
+pub mod biodivine_std;
 mod display_boolean_network;
 mod display_regulatory_graph;
 mod impl_binary_op;

--- a/src/parser/from_string_boolean_network.rs
+++ b/src/parser/from_string_boolean_network.rs
@@ -87,9 +87,9 @@ impl TryFrom<&str> for BooleanNetwork {
 
 #[cfg(test)]
 mod tests {
+    use crate::biodivine_std::structs::build_index_map;
     use crate::BinaryOp::{And, Iff, Imp, Or, Xor};
     use crate::{BooleanNetwork, FnUpdate, Parameter, ParameterId, RegulatoryGraph, VariableId};
-    use biodivine_lib_std::util::build_index_map;
     use std::convert::TryFrom;
 
     #[test]


### PR DESCRIPTION
At the moment, we use `biodivine-lib-std` for definitions like `Graph` and `IdState`. This turned out to be rather problematic because `biodivine-lib-std` is far from stable and we can't publish a semi-stable version of this crate without it. 

Therefore I removed all references to `lib-std` from the project and replaced them with a local implementation in module `biodivine-std`. The change is quite small, but will affect anyone using this as this is a breaking API change (albeit one that can be fixed by simply replacing the imports).