### PR TITLE
Extended symbolic domain

### DIFF
--- a/src/symbolic_async_graph/bdd_set.rs
+++ b/src/symbolic_async_graph/bdd_set.rs
@@ -1,0 +1,83 @@
+use crate::biodivine_std::traits::Set;
+use biodivine_lib_bdd::Bdd;
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+use std::ops::Shr;
+
+/// A simple trait that is implemented by symbolic sets represented using `Bdd` objects.
+///
+/// Historically, many of these methods were implemented directly by the actual objects
+/// (and are still implemented for compatibility reasons). However, they can also be implemented
+/// by this "blanket" implementation which might be easier to use, as we don't need to
+/// reimplement each method for every type.
+pub trait BddSet {
+    /// A reference to the underlying `Bdd`.
+    fn as_bdd(&self) -> &Bdd;
+    /// Make a copy of this set but use a completely new BDD instead. This is very much
+    /// unsafe, so make sure to only use it with the "right" BDDs.
+    fn copy(&self, bdd: Bdd) -> Self;
+
+    /// The number of BDD variables that are actually used by this encoding (they don't have
+    /// to appear in the actual BDD, they just theoretically appear in the encoding).
+    fn active_variables(&self) -> u16;
+
+    /// Compute the number of BDD nodes required to represent this set.
+    fn symbolic_size(&self) -> usize {
+        self.as_bdd().size()
+    }
+
+    /// Compute the exact cardinality of this symbolic set.
+    fn exact_cardinality(&self) -> BigInt {
+        let unused_variables = self.as_bdd().num_vars() - self.active_variables();
+        self.as_bdd().exact_cardinality().shr(unused_variables)
+    }
+
+    /// Compute an "approximate" cardinality of this symbolic set.
+    ///
+    /// The value is approximate because the limitations of `f64` can apply during computation.
+    fn approx_cardinality(&self) -> f64 {
+        let cardinality = self.as_bdd().cardinality();
+        let unused_variables = self.as_bdd().num_vars() - self.active_variables();
+        let cardinality = cardinality / 2.0f64.powi(i32::from(unused_variables));
+        if cardinality.is_nan() || cardinality.is_infinite() {
+            // If the result is invalid, try to recompute it with
+            // better precision.
+            self.exact_cardinality().to_f64().unwrap_or(f64::INFINITY)
+        } else {
+            cardinality
+        }
+    }
+}
+
+impl<T: BddSet + Clone> Set for T {
+    fn union(&self, other: &Self) -> Self {
+        self.copy(self.as_bdd().or(other.as_bdd()))
+    }
+
+    fn intersect(&self, other: &Self) -> Self {
+        self.copy(self.as_bdd().and(other.as_bdd()))
+    }
+
+    fn minus(&self, other: &Self) -> Self {
+        self.copy(self.as_bdd().and_not(other.as_bdd()))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.as_bdd().is_false()
+    }
+
+    fn is_subset(&self, other: &Self) -> bool {
+        /*
+           If A is a subset of B, then (A and not B) is `false` (everything that is in A is in B).
+           The following operation can only return a `false` BDD (due to the limit argument).
+           Any other result will terminate early and be returned as `None`.
+        */
+        Bdd::binary_op_with_limit(
+            1,
+            self.as_bdd(),
+            other.as_bdd(),
+            biodivine_lib_bdd::op_function::and_not,
+        )
+        .is_some()
+    }
+}

--- a/src/symbolic_async_graph/mod.rs
+++ b/src/symbolic_async_graph/mod.rs
@@ -127,7 +127,15 @@ pub struct SymbolicAsyncGraph {
 #[derive(Clone)]
 pub struct SymbolicContext {
     bdd: BddVariableSet,
+    // One symbolic variable for each network variable.
     state_variables: Vec<BddVariable>,
+    // A (possibly empty) list of extra symbolic variables for each network variable.
+    extra_state_variables: Vec<Vec<BddVariable>>,
+    // The same variables as above, but in one list (some operations only need this representation
+    // and it could take us some time to compute it for large models).
+    all_extra_state_variables: Vec<BddVariable>,
+    // All symbolic variables representing parameters. The association between
+    // variables and parameters is then managed by `FunctionTable` objects below.
     parameter_variables: Vec<BddVariable>,
     explicit_function_tables: Vec<FunctionTable>,
     implicit_function_tables: Vec<Option<FunctionTable>>,

--- a/src/symbolic_async_graph/mod.rs
+++ b/src/symbolic_async_graph/mod.rs
@@ -55,6 +55,13 @@ mod _impl_symbolic_async_graph_operators;
 /// **(internal)** Implementation of the `SymbolicContext`.
 mod _impl_symbolic_context;
 
+/// A module with a trait that describes common methods shared by all set representations
+/// based on BDDs.
+///
+/// These methods should eventually replace code that was previously duplicated across multiple
+/// set objects but is kept there for now due to compatibility.
+mod bdd_set;
+
 /// Symbolic representation of a color set.
 ///
 /// Implementation contains all symbolic variables, but state variables are unconstrained.


### PR DESCRIPTION
This PR should mostly generalise the work completed as part of `dev-hctl` by @ondrej33, such that the resulting `SymbolicContext` can be also used for other applications that assume multiple BDD variables associated to every network variable.

Overall, there shouldn't be any breaking changes, however, there is a minor adjustment to how symbolic set operations are implemented which I wanted to do for quite some time.

 - There is a new constructor `SymbolicContext::with_extra_state_variables`, which you can use to create a symbolic context with an arbitrary number of extra BDD variables.
 - To access these extra variables, you can use `SymbolicContext::all_extra_state_variables`, `SymbolicContext::extra_state_variables`, `SymbolicContext::extra_state_variables_by_offset`, `SymbolicContext::get_extra_state_variable`, and `SymbolicContext::mk_extra_state_variable_is_true`.
 - Just in case you need it, there is now also `SymbolicContext::num_state_variables`, `SymbolicContext::num_parameter_variables`, and `SymbolicContext::num_extra_state_variables`.
 - Similarly, there is a new constructor `SymbolicAsyncGraph::with_custom_context` that you can use to create a graph with a specific context and "unit" symbolic universe. There are several caveats as to how the `SymbolicAsyncGraph` can break if you mix the extra symbolic variables into the existing data structures, but as long as you use them outside of the `SymbolicAsyncGraph` API, you should be fine.
 - There is `SymbolicAsyncGraph::existential_extra_variable_projection` and `SymbolicAsyncGraph::universal_extra_variable_projection` which project a symbolic set that uses extra state variables onto a normal set that is guaranteed to be compatible with this symbolic graph.
 - Computation of `approx_cardinality` and `exact_cardinality` has been adjusted to account for extra symbolic variables.
 - Finally, there is a new trait called `BddSet` which now provides default implementations for most common symbolic operations (including the whole `Set` trait). This removes a lot of redundant code, but some of the old methods are still included to avoid breaking compatibility. Later, we should deprecate them and remove them from the library.