### PR TITLE
Enable fully symbolic network reduction

### DIFF
--- a/src/_aeon_parser/_from_string_for_boolean_network.rs
+++ b/src/_aeon_parser/_from_string_for_boolean_network.rs
@@ -204,9 +204,9 @@ a -?? a
 b -|? c
 c -? a
 c -> d
-$a: (a & (p(c) => (c | c)))
-$b: (p(a) <=> q(a, a))
-$c: (q(b, b) => !(b ^ k))
+$a: a & (p(c) => (c | c))
+$b: p(a) <=> q(a, a)
+$c: q(b, b) => !(b ^ k)
 ";
 
         assert_eq!(

--- a/src/_impl_space.rs
+++ b/src/_impl_space.rs
@@ -54,7 +54,11 @@ impl Space {
     /// Create a new space tracking the variables of the given network, where all values are
     /// initially assigned as `Any`.
     pub fn new(network: &BooleanNetwork) -> Space {
-        Space(vec![Any; network.num_vars()])
+        Self::new_raw(network.num_vars())
+    }
+
+    pub fn new_raw(num_vars: usize) -> Space {
+        Space(vec![Any; num_vars])
     }
 
     /// Convert a list of values (such as used by `SymbolicAsyncGraph`) into a proper "space" object.

--- a/src/bin/bench_fixed_points_naive.rs
+++ b/src/bin/bench_fixed_points_naive.rs
@@ -14,7 +14,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let fixed_points = FixedPoints::naive_symbolic(&stg, stg.unit_colored_vertices());
     println!(

--- a/src/bin/bench_fixed_points_symbolic.rs
+++ b/src/bin/bench_fixed_points_symbolic.rs
@@ -14,7 +14,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let fixed_points = FixedPoints::symbolic(&stg, stg.unit_colored_vertices());
     println!(

--- a/src/bin/bench_fixed_points_symbolic_colors.rs
+++ b/src/bin/bench_fixed_points_symbolic_colors.rs
@@ -14,7 +14,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let fixed_points = FixedPoints::symbolic_colors(&stg, stg.unit_colored_vertices());
     println!(

--- a/src/bin/bench_fixed_points_symbolic_iterator.rs
+++ b/src/bin/bench_fixed_points_symbolic_iterator.rs
@@ -15,7 +15,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
     let stg = Arc::new(stg);
 
     let dimensions = usize::from(stg.symbolic_context().bdd_variable_set().num_vars());

--- a/src/bin/bench_fixed_points_symbolic_vertices.rs
+++ b/src/bin/bench_fixed_points_symbolic_vertices.rs
@@ -14,7 +14,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let fixed_points = FixedPoints::symbolic_vertices(&stg, stg.unit_colored_vertices());
     println!(

--- a/src/bin/bench_reach.rs
+++ b/src/bin/bench_reach.rs
@@ -15,7 +15,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(&model.clone()).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let mut universe = stg.mk_unit_colored_vertices();
     while !universe.is_empty() {

--- a/src/bin/bench_reach.rs
+++ b/src/bin/bench_reach.rs
@@ -15,7 +15,7 @@ fn main() {
         model.num_parameters()
     );
 
-    let stg = SymbolicAsyncGraph::new(model.clone()).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model.clone()).unwrap();
 
     let mut universe = stg.mk_unit_colored_vertices();
     while !universe.is_empty() {

--- a/src/bin/bench_trap_spaces_minimal.rs
+++ b/src/bin/bench_trap_spaces_minimal.rs
@@ -6,7 +6,7 @@ fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let bn = BooleanNetwork::try_from_file(args[1].as_str()).unwrap();
     let ctx = SymbolicSpaceContext::new(&bn);
-    let stg = SymbolicAsyncGraph::with_space_context(bn.clone(), &ctx).unwrap();
+    let stg = SymbolicAsyncGraph::with_space_context(&bn.clone(), &ctx).unwrap();
 
     let unit_set = ctx.mk_unit_colored_spaces(&stg);
     let essential_traps = TrapSpaces::essential_symbolic(&bn, &ctx, &unit_set);

--- a/src/bin/bench_trap_spaces_minimal.rs
+++ b/src/bin/bench_trap_spaces_minimal.rs
@@ -6,7 +6,7 @@ fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let bn = BooleanNetwork::try_from_file(args[1].as_str()).unwrap();
     let ctx = SymbolicSpaceContext::new(&bn);
-    let stg = SymbolicAsyncGraph::with_space_context(&bn.clone(), &ctx).unwrap();
+    let stg = SymbolicAsyncGraph::with_space_context(&bn, &ctx).unwrap();
 
     let unit_set = ctx.mk_unit_colored_spaces(&stg);
     let essential_traps = TrapSpaces::essential_symbolic(&bn, &ctx, &unit_set);

--- a/src/bin/check_fixed_points.rs
+++ b/src/bin/check_fixed_points.rs
@@ -26,7 +26,7 @@ fn main() {
         model.num_vars(),
         model.num_parameters()
     );
-    let stg = SymbolicAsyncGraph::new(model).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let start = SystemTime::now();
     println!("Search for fixed-point colors...");

--- a/src/bin/check_fixed_points_solver.rs
+++ b/src/bin/check_fixed_points_solver.rs
@@ -25,7 +25,7 @@ fn main() {
 
     let z3 = z3::Context::new(&z3::Config::new());
     let ctx = BnSolverContext::new(&z3, model.clone());
-    let stg = SymbolicAsyncGraph::new(model.clone()).unwrap();
+    let stg = SymbolicAsyncGraph::new(&model).unwrap();
 
     let all_vertices = vec![Space::new(&model)];
     let iterator = FixedPoints::solver_iterator(&ctx, &all_vertices, &[]);

--- a/src/fixed_points/mod.rs
+++ b/src/fixed_points/mod.rs
@@ -31,7 +31,7 @@ use crate::Space;
 /// (The module is hidden, but we re-export iterator in this module)
 mod symbolic_iterator;
 use crate::symbolic_async_graph::projected_iteration::MixedProjection;
-use crate::VariableId;
+use crate::{BooleanNetwork, VariableId};
 pub use symbolic_iterator::SymbolicIterator;
 
 /// Implements the iterator used by `FixedPoints::solver_iterator`.
@@ -74,7 +74,6 @@ impl FixedPoints {
         }
 
         let mut to_merge: Vec<GraphColoredVertices> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -157,7 +156,6 @@ impl FixedPoints {
         }
 
         let mut to_merge: Vec<Bdd> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -219,6 +217,7 @@ impl FixedPoints {
     /// to subset of states/functions. For now, we do not provide extra methods for this, as it
     /// is not a very common use case. But if you want it, get in touch.
     pub fn symbolic_projection<'a>(
+        network: &BooleanNetwork,
         stg: &'a SymbolicAsyncGraph,
         restriction: &GraphColoredVertices,
         retain_state: &[VariableId],
@@ -233,7 +232,6 @@ impl FixedPoints {
         }
 
         let mut to_merge: Vec<Bdd> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -260,7 +258,7 @@ impl FixedPoints {
             project.remove(&ctx.get_state_variable(*var));
         }
         for var in retain_function {
-            if let Some(function) = stg.as_network().get_update_function(*var) {
+            if let Some(function) = network.get_update_function(*var) {
                 for p_id in function.collect_parameters() {
                     for p in ctx.get_explicit_function_table(p_id).symbolic_variables() {
                         project.remove(p);
@@ -451,7 +449,6 @@ impl FixedPoints {
         }
 
         let mut to_merge: Vec<Bdd> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -482,7 +479,7 @@ impl FixedPoints {
         let bdd =
             Self::symbolic_merge(stg.symbolic_context().bdd_variable_set(), to_merge, project);
 
-        let vertices = stg.empty_vertices().vertices().copy(bdd);
+        let vertices = stg.empty_colored_vertices().vertices().copy(bdd);
 
         if cfg!(feature = "print-progress") {
             println!(
@@ -510,7 +507,6 @@ impl FixedPoints {
         }
 
         let mut to_merge: Vec<Bdd> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -541,7 +537,7 @@ impl FixedPoints {
         let bdd =
             Self::symbolic_merge(stg.symbolic_context().bdd_variable_set(), to_merge, project);
 
-        let colors = stg.empty_vertices().colors().copy(bdd);
+        let colors = stg.empty_colored_vertices().colors().copy(bdd);
 
         if cfg!(feature = "print-progress") {
             println!(
@@ -695,7 +691,7 @@ mod tests {
     #[test]
     pub fn simple_fixed_point_test() {
         let bn = BooleanNetwork::try_from_file("aeon_models/g2a_p9.aeon").unwrap();
-        let stg = SymbolicAsyncGraph::new(bn).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 
         let naive = FixedPoints::naive_symbolic(&stg, stg.unit_colored_vertices());
         let symbolic = FixedPoints::symbolic(&stg, stg.unit_colored_vertices());
@@ -732,13 +728,14 @@ mod tests {
     #[test]
     pub fn simple_projected_fixed_point_test() {
         let bn = BooleanNetwork::try_from_file("aeon_models/g2a_p9.aeon").unwrap();
-        let stg = SymbolicAsyncGraph::new(bn.clone()).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 
         let ccr_m = bn.as_graph().find_variable("CcrM").unwrap();
         let dna = bn.as_graph().find_variable("DnaA").unwrap();
 
         // Compute how DnaA/CcrM fixed-points depend on the CcrM function.
         let projection = FixedPoints::symbolic_projection(
+            &bn,
             &stg,
             stg.unit_colored_vertices(),
             &[ccr_m, dna],

--- a/src/fixed_points/solver_iterator.rs
+++ b/src/fixed_points/solver_iterator.rs
@@ -200,7 +200,7 @@ mod tests {
         let z3 = z3::Context::new(&z3::Config::new());
 
         let bn = BooleanNetwork::try_from_file("aeon_models/g2a_p1026.aeon").unwrap();
-        let stg = SymbolicAsyncGraph::new(bn.clone()).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
         let ctx = BnSolverContext::new(&z3, bn.clone());
 
         let mut fixed_points = FixedPoints::naive_symbolic(&stg, stg.unit_colored_vertices());

--- a/src/fixed_points/symbolic_iterator.rs
+++ b/src/fixed_points/symbolic_iterator.rs
@@ -186,7 +186,7 @@ impl<'a> Iterator for SymbolicIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
-            .map(|bdd| self.stg.empty_vertices().copy(bdd))
+            .map(|bdd| self.stg.empty_colored_vertices().copy(bdd))
     }
 }
 
@@ -199,7 +199,6 @@ impl<'a> SymbolicIterator<'a> {
         limit: usize,
     ) -> SymbolicIterator<'a> {
         let mut to_merge: Vec<Bdd> = stg
-            .as_network()
             .variables()
             .map(|var| {
                 let can_step = stg.var_can_post(var, stg.unit_colored_vertices());
@@ -221,7 +220,6 @@ impl<'a> SymbolicIterator<'a> {
         }
 
         let mut clauses: Vec<BddPartialValuation> = stg
-            .as_network()
             .variables()
             .flat_map(|it| {
                 let can_step = stg.var_can_post(it, restriction);
@@ -299,7 +297,7 @@ mod tests {
     #[test]
     pub fn test_symbolic_iterator() {
         let bn = BooleanNetwork::try_from_file("aeon_models/g2a_p1026.aeon").unwrap();
-        let stg = SymbolicAsyncGraph::new(bn).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 
         let mut set = FixedPoints::naive_symbolic(&stg, stg.unit_colored_vertices());
 

--- a/src/symbolic_async_graph/_impl_graph_colored_vertices.rs
+++ b/src/symbolic_async_graph/_impl_graph_colored_vertices.rs
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn basic_colored_spaces_set_test() {
         let bn = BooleanNetwork::try_from_file("aeon_models/005.aeon").unwrap();
-        let stg = SymbolicAsyncGraph::new(bn.clone()).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 
         let unit = stg.mk_unit_colored_vertices();
         assert!(!unit.is_singleton());

--- a/src/symbolic_async_graph/_impl_symbolic_async_graph.rs
+++ b/src/symbolic_async_graph/_impl_symbolic_async_graph.rs
@@ -405,7 +405,7 @@ impl SymbolicAsyncGraph {
             return None;
         }
 
-        let new_context = self.symbolic_context.eliminate(variable);
+        let new_context = self.symbolic_context.eliminate_network_variable(variable);
 
         // State variables should not matter that much in the unit set, we can just erase it. The important
         // part is that we use the new symbolic context.

--- a/src/symbolic_async_graph/_impl_symbolic_async_graph_algorithm.rs
+++ b/src/symbolic_async_graph/_impl_symbolic_async_graph_algorithm.rs
@@ -14,7 +14,7 @@ impl SymbolicAsyncGraph {
     pub fn reach_forward(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
         let mut result = initial.clone();
         'fwd: loop {
-            for var in self.network.variables().rev() {
+            for var in self.variables().rev() {
                 let step = self.var_post_out(var, &result);
                 if !step.is_empty() {
                     result = result.union(&step);
@@ -32,7 +32,7 @@ impl SymbolicAsyncGraph {
     pub fn reach_backward(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
         let mut result = initial.clone();
         'bwd: loop {
-            for var in self.network.variables().rev() {
+            for var in self.variables().rev() {
                 let step = self.var_pre_out(var, &result);
                 if !step.is_empty() {
                     result = result.union(&step);
@@ -51,7 +51,7 @@ impl SymbolicAsyncGraph {
     pub fn trap_forward(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
         let mut result = initial.clone();
         'fwd: loop {
-            for var in self.network.variables().rev() {
+            for var in self.variables().rev() {
                 let step = self.var_can_post_out(var, &result);
                 if !step.is_empty() {
                     result = result.minus(&step);
@@ -70,7 +70,7 @@ impl SymbolicAsyncGraph {
     pub fn trap_backward(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
         let mut result = initial.clone();
         'bwd: loop {
-            for var in self.network.variables().rev() {
+            for var in self.variables().rev() {
                 let step = self.var_can_pre_out(var, &result);
                 if !step.is_empty() {
                     result = result.minus(&step);
@@ -105,7 +105,7 @@ mod tests {
         )
         .unwrap();
 
-        let stg = SymbolicAsyncGraph::new(bn).unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 
         let pivot = stg.unit_colored_vertices().pick_vertex();
         let fwd = stg.reach_forward(&pivot);

--- a/src/symbolic_async_graph/_impl_symbolic_async_graph_operators.rs
+++ b/src/symbolic_async_graph/_impl_symbolic_async_graph_operators.rs
@@ -44,7 +44,7 @@ impl SymbolicAsyncGraph {
         let symbolic_var = self.symbolic_context.state_variables[variable.0];
         let output = Bdd::fused_binary_flip_op(
             (&initial.bdd, None),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
             biodivine_lib_bdd::op_function::and,
         );
@@ -66,7 +66,7 @@ impl SymbolicAsyncGraph {
         let symbolic_var = self.symbolic_context.state_variables[variable.0];
         let output = Bdd::fused_binary_flip_op(
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             None,
             biodivine_lib_bdd::op_function::and,
         );
@@ -88,20 +88,11 @@ impl SymbolicAsyncGraph {
         // flip(set & !flip(set) & can_apply_function)
         let symbolic_var = self.symbolic_context.state_variables[variable.0];
         let output = Bdd::fused_ternary_flip_op(
-            (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&initial.bdd, None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
-            |a, b, c| {
-                // a & !b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(true), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(false), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            not_a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -123,18 +114,9 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             None,
-            |a, b, c| {
-                // !a & b & c
-                match (a, b, c) {
-                    (Some(true), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(false), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            not_a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -156,18 +138,9 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
-            |a, b, c| {
-                // a & b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -189,18 +162,9 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             None,
-            |a, b, c| {
-                // a & b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -218,7 +182,7 @@ impl SymbolicAsyncGraph {
     ) -> GraphColoredVertices {
         // set & can_apply_function
         GraphColoredVertices::new(
-            initial.bdd.and(&self.update_functions[variable.0]),
+            initial.bdd.and(&self.fn_transition[variable.0]),
             &self.symbolic_context,
         )
     }
@@ -238,7 +202,7 @@ impl SymbolicAsyncGraph {
         let symbolic_var = self.symbolic_context.state_variables[variable.0];
         let output = Bdd::fused_binary_flip_op(
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
             biodivine_lib_bdd::op_function::and,
         );
@@ -260,20 +224,11 @@ impl SymbolicAsyncGraph {
         // set & !flip(set) & can_apply_function
         let symbolic_var = self.symbolic_context.state_variables[variable.0];
         let output = Bdd::fused_ternary_flip_op(
-            (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&initial.bdd, None),
+            (&self.fn_transition[variable.0], None),
             None,
-            |a, b, c| {
-                // a & !b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(true), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(false), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            not_a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -295,18 +250,9 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
-            |a, b, c| {
-                // !a & b & c
-                match (a, b, c) {
-                    (Some(true), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(false), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            not_a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -328,18 +274,9 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             None,
-            |a, b, c| {
-                // a & b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
     }
@@ -361,20 +298,33 @@ impl SymbolicAsyncGraph {
         let output = Bdd::fused_ternary_flip_op(
             (&initial.bdd, None),
             (&initial.bdd, Some(symbolic_var)),
-            (&self.update_functions[variable.0], None),
+            (&self.fn_transition[variable.0], None),
             Some(symbolic_var),
-            |a, b, c| {
-                // a & b & c
-                match (a, b, c) {
-                    (Some(false), _, _) => Some(false),
-                    (_, Some(false), _) => Some(false),
-                    (_, _, Some(false)) => Some(false),
-                    (Some(true), Some(true), Some(true)) => Some(true),
-                    _ => None,
-                }
-            },
+            a_and_b_and_c,
         );
         GraphColoredVertices::new(output, &self.symbolic_context)
+    }
+}
+
+pub(crate) fn a_and_b_and_c(a: Option<bool>, b: Option<bool>, c: Option<bool>) -> Option<bool> {
+    // a & b & c
+    match (a, b, c) {
+        (Some(false), _, _) => Some(false),
+        (_, Some(false), _) => Some(false),
+        (_, _, Some(false)) => Some(false),
+        (Some(true), Some(true), Some(true)) => Some(true),
+        _ => None,
+    }
+}
+
+pub(crate) fn not_a_and_b_and_c(a: Option<bool>, b: Option<bool>, c: Option<bool>) -> Option<bool> {
+    // !a & b & c
+    match (a, b, c) {
+        (Some(true), _, _) => Some(false),
+        (_, Some(false), _) => Some(false),
+        (_, _, Some(false)) => Some(false),
+        (Some(false), Some(true), Some(true)) => Some(true),
+        _ => None,
     }
 }
 
@@ -398,36 +348,32 @@ impl SymbolicAsyncGraph {
 impl SymbolicAsyncGraph {
     /// Compute the result of applying `post` with *all* update functions to the `initial` set.
     pub fn post(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_post(v, initial))
             })
     }
 
     /// Compute the result of applying `pre` with *all* update functions to the `initial` set.
     pub fn pre(&self, initial: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_pre(v, initial))
             })
     }
 
     /// Compute the subset of `set` that can perform *some* `post` operation.
     pub fn can_post(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_post(v, set))
             })
     }
 
     /// Compute the subset of `set` that can perform *some* `pre` operation.
     pub fn can_pre(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_pre(v, set))
             })
     }
@@ -435,9 +381,8 @@ impl SymbolicAsyncGraph {
     /// Compute the subset of `set` that can perform *some* `post` operation which leads
     /// to a state within `set`.
     pub fn can_post_within(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_post_within(v, set))
             })
     }
@@ -447,17 +392,15 @@ impl SymbolicAsyncGraph {
     ///
     /// Note that this also includes states which cannot perform any `post` operation.
     pub fn will_post_within(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
+        self.variables()
             .fold(set.clone(), |r, v| r.minus(&self.var_can_post_out(v, set)))
     }
 
     /// Compute the subset of `set` that can perform *some* `pre` operation which leads
     /// to a state within `set`.
     pub fn can_pre_within(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_pre_within(v, set))
             })
     }
@@ -467,17 +410,15 @@ impl SymbolicAsyncGraph {
     ///
     /// Note that this also includes states which cannot perform any `pre` operation.
     pub fn will_pre_within(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
+        self.variables()
             .fold(set.clone(), |r, v| r.minus(&self.var_can_pre_out(v, set)))
     }
 
     /// Compute the subset of `set` that can perform *some* `post` operation which leads
     /// to a state outside of `set`.
     pub fn can_post_out(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_post_out(v, set))
             })
     }
@@ -487,7 +428,7 @@ impl SymbolicAsyncGraph {
     ///
     /// Note that this also includes states which cannot perform any `post` operation.
     pub fn will_post_out(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network.variables().fold(set.clone(), |r, v| {
+        self.variables().fold(set.clone(), |r, v| {
             r.minus(&self.var_can_post_within(v, set))
         })
     }
@@ -495,9 +436,8 @@ impl SymbolicAsyncGraph {
     /// Compute the subset of `set` that can perform *some* `pre` operation which leads
     /// to a state outside of `set`.
     pub fn can_pre_out(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network
-            .variables()
-            .fold(self.mk_empty_vertices(), |r, v| {
+        self.variables()
+            .fold(self.mk_empty_colored_vertices(), |r, v| {
                 r.union(&self.var_can_pre_out(v, set))
             })
     }
@@ -507,7 +447,7 @@ impl SymbolicAsyncGraph {
     ///
     /// Note that this also includes states which cannot perform any `pre` operation.
     pub fn will_pre_out(&self, set: &GraphColoredVertices) -> GraphColoredVertices {
-        self.network.variables().fold(set.clone(), |r, v| {
+        self.variables().fold(set.clone(), |r, v| {
             r.minus(&self.var_can_pre_within(v, set))
         })
     }
@@ -535,8 +475,8 @@ mod tests {
         ",
         )
         .unwrap();
-        let stg = SymbolicAsyncGraph::new(bn).unwrap();
-        let id_b = stg.as_network().as_graph().find_variable("B").unwrap();
+        let stg = SymbolicAsyncGraph::new(&bn).unwrap();
+        let id_b = bn.as_graph().find_variable("B").unwrap();
         let b_is_true = stg.fix_network_variable(id_b, true);
         let b_is_false = stg.fix_network_variable(id_b, false);
 

--- a/src/symbolic_async_graph/_impl_symbolic_context.rs
+++ b/src/symbolic_async_graph/_impl_symbolic_context.rs
@@ -164,7 +164,7 @@ impl SymbolicContext {
     /// by the eliminated variable. However, you cannot access them using the normal methods
     /// (e.g. [SymbolicContext::get_extra_state_variable]), only through the full list
     /// (i.e. [SymbolicContext::all_extra_state_variables]).
-    pub fn eliminate(&self, variable: VariableId) -> SymbolicContext {
+    pub fn eliminate_network_variable(&self, variable: VariableId) -> SymbolicContext {
         let index = variable.to_index();
         let mut result = self.clone();
         // Remove the variable from all variable-indexed lists. The symbolic variables still remain in the

--- a/src/trap_spaces/_impl_network_colored_spaces.rs
+++ b/src/trap_spaces/_impl_network_colored_spaces.rs
@@ -216,7 +216,7 @@ mod tests {
     fn basic_colored_spaces_set_test() {
         let bn = BooleanNetwork::try_from_file("aeon_models/005.aeon").unwrap();
         let ctx = SymbolicSpaceContext::new(&bn);
-        let stg = SymbolicAsyncGraph::with_space_context(bn.clone(), &ctx).unwrap();
+        let stg = SymbolicAsyncGraph::with_space_context(&bn, &ctx).unwrap();
 
         let unit = ctx.mk_unit_colored_spaces(&stg);
         assert!(!unit.is_singleton());

--- a/src/trap_spaces/_impl_trap_spaces.rs
+++ b/src/trap_spaces/_impl_trap_spaces.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_trap_spaces() {
         let network = BooleanNetwork::try_from_file("./aeon_models/005.aeon").unwrap();
         let ctx = SymbolicSpaceContext::new(&network);
-        let stg = SymbolicAsyncGraph::with_space_context(network.clone(), &ctx).unwrap();
+        let stg = SymbolicAsyncGraph::with_space_context(&network, &ctx).unwrap();
         let unit = ctx.mk_unit_colored_spaces(&stg);
 
         let essential_traps = TrapSpaces::essential_symbolic(&network, &ctx, &unit);

--- a/src/tutorial/p03_symbolic_async_graph.rs
+++ b/src/tutorial/p03_symbolic_async_graph.rs
@@ -44,7 +44,7 @@
 //! // At this point, the implementation checks if there is at least one parametrisation which
 //! // satisfies all the requirements imposed by the RegulatoryGraph. If no such parametrisation
 //! // exists, an error is returned, typically also with an explanation why.
-//! let stg = SymbolicAsyncGraph::new(bn)?;
+//! let stg = SymbolicAsyncGraph::new(&bn)?;
 //!
 //! // Once we have a `SymbolicAsyncGraph`, we can access the `GraphVertices`, `GraphColors`
 //! // and `GraphColoredVertices`. Basic methods return a reference, `mk_*` methods create
@@ -52,18 +52,20 @@
 //! assert_eq!(32.0, stg.unit_colored_vertices().approx_cardinality());
 //! assert_eq!(8.0, stg.unit_colored_vertices().vertices().approx_cardinality());
 //! assert_eq!(4.0, stg.unit_colored_vertices().colors().approx_cardinality());
-//! assert!(stg.empty_vertices().is_empty());
+//! assert!(stg.empty_colored_vertices().is_empty());
 //! assert!(stg.mk_empty_colors().is_empty());
 //! assert_eq!(stg.mk_unit_colors(), stg.unit_colored_vertices().colors());
 //! // WARNING: Remember that floating point numbers may not be exact for larger values.
 //! // In fact, for some very large models, the set size can be simply approximated to infinity.
 //!
 //! // You can still access the underlying network of the graph:
-//! assert_eq!(3, stg.as_network().num_vars());
+//! assert_eq!(3, stg.as_network().unwrap().num_vars());
+//! // Just note that in some advanced instances, the network may not exist, in which case
+//! // `as_network` returns `None`
 //!
 //! // You can also obtain a set where all vertices have a Boolean variable set
 //! // to the given value:
-//! let id_a = stg.as_network().as_graph().find_variable("A").unwrap();
+//! let id_a = bn.as_graph().find_variable("A").unwrap();
 //! let a_is_true: GraphColoredVertices = stg.fix_network_variable(id_a, true);
 //! // This can be used to (for example) construct a set of initial states specified by the user.
 //!
@@ -131,8 +133,8 @@
 //! #     A -| A
 //! #     $A: C | f(A, B)
 //! # ").unwrap();
-//! # let stg = SymbolicAsyncGraph::new(bn)?;
-//! let id_b = stg.as_network().as_graph().find_variable("B").unwrap();
+//! # let stg = SymbolicAsyncGraph::new(&bn)?;
+//! let id_b = bn.as_graph().find_variable("B").unwrap();
 //! let b_is_true = stg.fix_network_variable(id_b, true);
 //! let b_is_false = stg.fix_network_variable(id_b, false);
 //!

--- a/src/tutorial/p04_graph_algorithm_sample.rs
+++ b/src/tutorial/p04_graph_algorithm_sample.rs
@@ -94,7 +94,7 @@
 //!     A -| A
 //!     $A: C | f(A, B)
 //! ").unwrap();
-//! let stg = SymbolicAsyncGraph::new(bn).unwrap();
+//! let stg = SymbolicAsyncGraph::new(&bn).unwrap();
 //!
 //! // Note that since the symbolic graph contains different transitions for different colors,
 //! // this will create SCCs that overlap for some colors but are completely different for others.


### PR DESCRIPTION
This PR should finally enable fully symbolic network reduction at the level of `SymbolicAsyncGraph`.

Specifically:
 - `FnUpdate::to_string` can now skip parenthesis around nested and/or functions, meaning the output is more readable, especially in witness networks (e.g. `a & b & (a | c | d)` instead of `((a & b) & ((a | c) | d))`.
 - Added `FnUpdate::mk_conjunction` and `FnUpdate::mk_disjunction` that can be used to create update functions using n-ary operators. This also simplifies `FnUpdate::build_from_bdd`.
 - Added `Space::new_raw` which takes the number of variables instead of the whole network.
 - **[breaking]** `SymbolicAsyncGraph::new` and other variants now only need a reference to a Boolean network, since the network is no longer a required part of the structure (although in most cases, it is simply copied).
 - **[breaking]** `SymbolicAsyncGraph::empty_vertices` and `SymbolicAsyncGraph::mk_empty_vertices` renamed to `empty_colored_vertices`. This was a typo and we should have done this a long time ago.
 - Added proper `SymbolicAsyncGraph::unit_vertices` and `SymbolicAsyncGraph::empty_vertices` methods.
 - **[breaking]** `SymbolicAsyncGraph::as_network` now returns `Option<BooleanNetwork>`. The code that was using the underlying network was rewritten to use one of the new utility methods instead. With that said...
 - Added a bunch of utility methods to `SymbolicAsyncGraph` and `SymbolicContext` for managing `VariableId` objects without the underlying `BooleanNetwork` (namely `SymbolicContext::find_network_variable`, `SymbolicContext::get_network_variable_name`, `SymbolicContext::network_variables`, `SymbolicContext::find_state_variable`, `SymbolicAsyncGraph::get_symbolic_fn_update`, `SymbolicAsyncGraph::get_variable_name`, `SymbolicAsyncGraph::num_vars`, and `SymbolicAsyncGraph::variables`).
 - Added `SymbolicContext::eliminate_variable` which is used by the reduction.
 - Added `SymbolicContext::mk_instantiated_fn_update` which is a utility function used by witness generation and projected iteration.
 - Added `SymbolicAsyncGraph::new_raw` which can be used to create a graph from BDDs, without the underlying Boolean network.
 - Added `SymbolicAsyncGraph::inline_symbolic`, which implements the actual variable inlining.