### PR TITLE
Add the ability to create "canonical symbolic contexts"

### DIFF
--- a/src/symbolic_async_graph/_impl_function_table.rs
+++ b/src/symbolic_async_graph/_impl_function_table.rs
@@ -14,7 +14,8 @@ impl FunctionTable {
                 bdd_builder.make_variable(bdd_var_name.as_str())
             })
             .collect();
-        FunctionTable { arity, rows }
+        let name = name.to_string();
+        FunctionTable { arity, rows, name }
     }
 
     /// List the symbolic variables that appear in this function table.
@@ -24,6 +25,11 @@ impl FunctionTable {
     /// don't care about their input valuations.
     pub fn symbolic_variables(&self) -> &Vec<BddVariable> {
         &self.rows
+    }
+
+    /// True if this [FunctionTable] contains the provided [BddVariable].
+    pub fn contains(&self, var: BddVariable) -> bool {
+        self.rows.contains(&var)
     }
 }
 

--- a/src/symbolic_async_graph/mod.rs
+++ b/src/symbolic_async_graph/mod.rs
@@ -169,8 +169,11 @@ pub struct SymbolicContext {
 /// The main functionality of a `FunctionTable` is that it provides an iterator over
 /// pairs of `Vec<bool>` (function input assignment) and `BddVariable`
 /// (corresponding symbolic variable).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionTable {
+    /// Original name of the function. This can be derived from the names of the symbolic variables, but it
+    /// is useful to have it around if we ever want to translate between representations.
+    name: String,
     pub arity: u16,
     rows: Vec<BddVariable>,
 }


### PR DESCRIPTION
This is rather intuitive: We can now convert an existing `SymbolicContext` with a bunch of extra variables into the "canonical" context which has nothing except for the state/parameter variables.