### PR TITLE
Better feedback vertex set computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ print-progress = []
 solver-z3 = ["dep:z3"]
 
 [dependencies]
+fxhash = "0.2.1"
 regex = "1.10.2"                # Regexes used for parsing of basic .aeon constructs.
 lazy_static = "1.4.0"           # Used for initialization of commonly used regexes.
 biodivine-lib-bdd = ">=0.5.6, <1.0.0"

--- a/src/_impl_regulatory_graph/signed_directed_graph/_cycle_detection.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_cycle_detection.rs
@@ -1,6 +1,8 @@
+use crate::Sign::Negative;
 use crate::VariableId;
 use crate::_impl_regulatory_graph::signed_directed_graph::{SdGraph, Sign};
-use std::collections::HashSet;
+use fxhash::FxBuildHasher;
+use std::collections::{HashMap, HashSet};
 use Sign::Positive;
 
 impl SdGraph {
@@ -26,6 +28,12 @@ impl SdGraph {
             restriction.contains(&pivot),
             "Pivot vertex must be present in the restriction set."
         );
+
+        /*
+           The following algorithm uses BFS to find the shortest cycle. It essentially
+           computes the shortest path from pivot to all vertices and terminates if it finds
+           a path back towards itself.
+        */
 
         // Shortest_cycle is called so often when computing a feedback vertex set, that this
         // actually helps with performance quite a bit compared to a normal hash map.
@@ -101,81 +109,128 @@ impl SdGraph {
             "Pivot vertex must be present in the restriction set."
         );
 
-        // Shortest_cycle is called so often when computing a feedback vertex set, that this
-        // actually helps with performance quite a bit compared to a normal hash map.
-        let mut shortest_positive_predecessor: Vec<Option<(VariableId, Sign)>> =
-            vec![None; self.successors.len()];
-        let mut shortest_negative_predecessor: Vec<Option<(VariableId, Sign)>> =
-            vec![None; self.successors.len()];
+        /*
+           The following algorithm uses dynamic programming to compute a table which specifies
+           for each (viable) variable-parity combination the shortest simple path towards the
+           pivot. Based on this shortest path, we can decide if there is an appropriate parity
+           cycle from pivot or not.
 
-        // No need for frontier to be a set, because each vertex is inserted only if it is
-        // inserted into `shortest_*_predecessor` first, where it is only inserted at most once.
-        let mut frontier = vec![(pivot, Positive)];
-        let mut length = 0usize;
-        while !frontier.is_empty() {
-            length += 1;
-            if length > upper_bound {
-                // There may be a cycle, but it has more than `upper_bound` edges.
-                return None;
+           The table is computed bottom-up, starting from direct predecessors. In each "main"
+           iteration, we check if a cycle is possible and terminate early if a cycle is found.
+
+           **Note that this is a tricky problem to solve exactly using pure DFS/BFS, even with
+           some clever memoization tricks. In particular, one has to properly save the tree of
+           shortest paths and at the same time ensure that these are indeed only simple paths.
+           If you ever modify this, test carefully! (random networks with 1000+ nodes seem to
+           be a good place to start)**
+
+           **Also note that you will be tempted to cut off a path if a shorter one is known.
+           This is not correct! There may be a very short path that goes to pivot but cannot be
+           used because we need the result to be a simple path. Instead, you probably really
+           need to keep all paths running until they either reach pivot or stop being simple.**
+
+           The use of FxHash is not super critical, but it helps if cycles are computed very
+           often (e.g. in FVS detection).
+        */
+
+        if upper_bound == 0 {
+            // No cycle can have zero edges.
+            return None;
+        }
+
+        // If pivot has a self-loop, just return it.
+        if self.successors[pivot.to_index()].contains(&(pivot, target_parity)) {
+            return Some(vec![pivot]);
+        }
+
+        if upper_bound == 1 {
+            // Only self-loop can have one edge.
+            return None;
+        }
+
+        // A vertex in a larger graph where each variable can be visited with a specific sign.
+        type Config = (VariableId, Sign);
+
+        let mut reaches_pivot_in_steps: Vec<HashMap<Config, Config, FxBuildHasher>> = Vec::new();
+        // Noone can reach pivot in zero steps.
+        reaches_pivot_in_steps.push(HashMap::with_hasher(FxBuildHasher::default()));
+
+        // Direct predecessors can reach pivot in zero steps.
+        let mut one_step = HashMap::with_hasher(FxBuildHasher::default());
+        for (pred, sign) in &self.predecessors[pivot.to_index()] {
+            if restriction.contains(pred) {
+                one_step.insert((*pred, *sign), (pivot, Positive));
             }
+        }
+        reaches_pivot_in_steps.push(one_step);
 
-            let mut new_frontier = Vec::with_capacity(frontier.len());
-            for (x, x_sign) in frontier {
-                for (succ, succ_sign) in &self.successors[x.to_index()] {
-                    let path_sign = x_sign + *succ_sign;
-                    if *succ == pivot && path_sign == target_parity {
-                        // Found cycle. Because this is BFS, the cycle is minimal,
-                        // we just have to back-track. However, it may not be simple: if it
-                        // contains the same node twice, it is not a valid cycle.
-                        let mut cycle = vec![(x, x_sign)];
-                        let mut cycle_set: HashSet<VariableId> = HashSet::from_iter([x]);
-                        while let Some((last, last_sign)) = cycle.last() {
-                            if *last == pivot {
-                                cycle.reverse();
-                                return Some(Vec::from_iter(cycle.into_iter().map(|(x, _)| x)));
-                            }
-                            let next = if *last_sign == Positive {
-                                shortest_positive_predecessor[last.to_index()].unwrap()
-                            } else {
-                                shortest_negative_predecessor[last.to_index()].unwrap()
-                            };
-
-                            if cycle_set.contains(&next.0) {
-                                // If duplicity is detected, the cycle is invalid.
-                                break;
-                            } else {
-                                // Otherwise extend the cycle with a new node.
-                                cycle_set.insert(next.0);
-                                cycle.push(next);
-                            }
-                        }
-                    }
-                    if *succ == pivot {
-                        // Eliminates some spurious cycles with node repetition.
-                        continue;
-                    }
-                    if !restriction.contains(succ) {
-                        // We don't want to leave `restriction`.
-                        continue;
-                    }
-                    let slot = if path_sign == Positive {
-                        &mut shortest_positive_predecessor[succ.to_index()]
-                    } else {
-                        &mut shortest_negative_predecessor[succ.to_index()]
+        let mut path_length = 1usize;
+        let mut go_through = 'search: loop {
+            // There is a negative pivot cycle of length `path_length + 1` if we can get directly
+            // from pivot to one of the viable path candidates.
+            let path_candidates = &reaches_pivot_in_steps[path_length];
+            for (succ, sign) in &self.successors[pivot.to_index()] {
+                if restriction.contains(succ) {
+                    let path_sign = match (target_parity, *sign) {
+                        (Negative, Negative) => Positive,
+                        (Negative, Positive) => Negative,
+                        (Positive, Negative) => Negative,
+                        (Positive, Positive) => Positive,
                     };
-                    if slot.is_some() {
-                        // This vertex was already discovered using a shorter or equivalent path.
-                        continue;
+                    if path_candidates.contains_key(&(*succ, path_sign)) {
+                        break 'search (*succ, path_sign);
                     }
-                    *slot = Some((x, x_sign));
-                    new_frontier.push((*succ, path_sign));
                 }
             }
 
-            frontier = new_frontier;
+            if path_length + 1 == upper_bound {
+                // All cycles from here on have more edges than the upper bound.
+                return None;
+            }
+
+            // If we haven't found a cycle with the current length, we need to extend the
+            // paths and try again.
+            path_length += 1;
+            let mut next_step = HashMap::with_hasher(FxBuildHasher::default());
+            for (x, x_sign) in path_candidates.keys() {
+                'pred: for (pred, pred_sign) in &self.predecessors[x.to_index()] {
+                    if restriction.contains(pred) && *pred != pivot {
+                        let mut check_simple = (*x, *x_sign);
+                        let mut check_simple_length = path_length - 1;
+                        while check_simple.0 != pivot {
+                            if check_simple.0 == *pred {
+                                // This predecessor is already used on the path we are at.
+                                // We can't use it again.
+                                continue 'pred;
+                            }
+                            check_simple = *reaches_pivot_in_steps[check_simple_length]
+                                .get(&check_simple)
+                                .unwrap();
+                            check_simple_length -= 1;
+                        }
+
+                        let pred_path_sign = *x_sign + *pred_sign;
+                        next_step.insert((*pred, pred_path_sign), (*x, *x_sign));
+                    }
+                }
+            }
+            if next_step.is_empty() {
+                // If we haven't found a nicer path for any vertex, there is no cycle.
+                return None;
+            }
+            reaches_pivot_in_steps.push(next_step);
+        };
+
+        let mut cycle = vec![pivot];
+        while go_through.0 != pivot {
+            cycle.push(go_through.0);
+            go_through = *reaches_pivot_in_steps[path_length]
+                .get(&go_through)
+                .unwrap();
+            path_length -= 1;
         }
 
-        None
+        Some(cycle)
     }
 }
 

--- a/src/_impl_regulatory_graph/signed_directed_graph/_cycle_detection.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_cycle_detection.rs
@@ -1,56 +1,9 @@
 use crate::VariableId;
-use crate::_impl_regulatory_graph::signed_directed_graph::Sign::Negative;
 use crate::_impl_regulatory_graph::signed_directed_graph::{SdGraph, Sign};
-use std::cmp::min;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use Sign::Positive;
 
 impl SdGraph {
-    /// Compute the length of the shortest cycle within `restriction` that contains `pivot`.
-    /// `None` if no such cycle exists.
-    ///
-    /// The length is in terms of edges (so cycle of length 1 is a self-loop). Panics if `pivot`
-    /// is not a member of `restriction`.
-    ///
-    /// Finally, you can restrict the search to only include cycles of a specific length
-    /// by providing the `upper_bound`.
-    pub fn shortest_cycle_length(
-        &self,
-        restriction: &HashSet<VariableId>,
-        pivot: VariableId,
-        upper_bound: usize,
-    ) -> Option<usize> {
-        assert!(restriction.contains(&pivot));
-
-        let mut visited = HashSet::from([pivot]);
-        let mut frontier = HashSet::from([pivot]);
-
-        let mut length = 0;
-        while !frontier.is_empty() {
-            length += 1;
-            if length > upper_bound {
-                return None;
-            }
-
-            let mut new_frontier = HashSet::new();
-            for x in frontier {
-                for (successor, _) in &self.successors[x.to_index()] {
-                    if *successor == pivot {
-                        return Some(length);
-                    }
-                    if restriction.contains(successor) && !visited.contains(successor) {
-                        visited.insert(*successor);
-                        new_frontier.insert(*successor);
-                    }
-                }
-            }
-
-            frontier = new_frontier;
-        }
-
-        None
-    }
-
     /// Compute the shortest cycle (or one of the shortest cycles) within `restriction` that
     /// also contains the `pivot` vertex. The result is a vector with pivot at position zero
     /// and other vertices in the order in which they appear on the cycle. If no such cycle
@@ -61,70 +14,71 @@ impl SdGraph {
     /// the two algorithms. Panics if `pivot` is not a member of `restriction`.
     ///
     /// Finally, you can restrict the search to only include cycles of a specific length
-    /// by providing the `upper_bound`.
+    /// by providing an inclusive `upper_bound` (the length is counted as the number of
+    /// edges in the cycle, i.e. a cycle is returned only if `edge_count <= upper_bound`).
     pub fn shortest_cycle(
         &self,
         restriction: &HashSet<VariableId>,
         pivot: VariableId,
         upper_bound: usize,
     ) -> Option<Vec<VariableId>> {
-        assert!(restriction.contains(&pivot));
+        assert!(
+            restriction.contains(&pivot),
+            "Pivot vertex must be present in the restriction set."
+        );
 
-        let mut best_cycle: Option<Vec<VariableId>> = None;
-        let mut best_cycle_length = usize::MAX;
-        let mut distances: HashMap<VariableId, usize> =
-            restriction.iter().map(|it| (*it, usize::MAX)).collect();
-        distances.insert(pivot, 0);
+        // Shortest_cycle is called so often when computing a feedback vertex set, that this
+        // actually helps with performance quite a bit compared to a normal hash map.
+        let mut shortest_predecessor: Vec<Option<VariableId>> = vec![None; self.successors.len()];
 
-        fn successor_function(
-            graph: &SdGraph,
-            restriction: &HashSet<VariableId>,
-            vertex: VariableId,
-        ) -> Vec<VariableId> {
-            graph.successors[vertex.to_index()]
-                .iter()
-                .map(|(it, _)| *it)
-                .filter(|it| restriction.contains(it))
-                .collect()
-        }
-
-        let mut stack = vec![(pivot, successor_function(self, restriction, pivot))];
-
-        while let Some((vertex, successors)) = stack.last_mut() {
-            let vertex_distance = distances[vertex];
-
-            if best_cycle_length <= vertex_distance || upper_bound <= vertex_distance {
-                stack.pop();
-                continue;
+        // No need for frontier to be a set, because each vertex is inserted only if it is
+        // inserted into `shorted_predecessor` first, where it is only inserted at most once.
+        let mut frontier = vec![pivot];
+        let mut length = 0usize;
+        while !frontier.is_empty() {
+            length += 1;
+            if length > upper_bound {
+                // There may be a cycle, but it has more than `upper_bound` edges.
+                return None;
             }
 
-            if let Some(successor) = successors.pop() {
-                let successor_distance = distances[&successor];
-                let new_successor_distance = min(successor_distance, vertex_distance + 1);
-                if new_successor_distance < successor_distance {
-                    // Note that this can't happen to the pivot since its distance is always zero.
-                    distances.insert(successor, new_successor_distance);
-                    stack.push((successor, successor_function(self, restriction, successor)));
-                } else if successor == pivot {
-                    // Hence we have to handle pivot independently.
-                    let cycle_on_stack: Vec<VariableId> = stack.iter().map(|(it, _)| *it).collect();
-                    if cycle_on_stack.len() < best_cycle_length {
-                        best_cycle_length = cycle_on_stack.len();
-                        best_cycle = Some(cycle_on_stack);
+            let mut new_frontier = Vec::with_capacity(frontier.len());
+            for x in frontier {
+                for (succ, _) in &self.successors[x.to_index()] {
+                    if *succ == pivot {
+                        // Found cycle. Because this is BFS, the cycle is minimal,
+                        // we just have to back-track.
+                        let mut cycle = vec![x];
+                        while let Some(last) = cycle.last() {
+                            if *last == pivot {
+                                // The cycle is complete. Reverse it and return.
+                                cycle.reverse();
+                                return Some(cycle);
+                            }
+                            cycle.push(shortest_predecessor[last.to_index()].unwrap());
+                        }
                     }
-                } else {
-                    // Otherwise, do nothing. The successor cannot be improved by this path.
+                    if !restriction.contains(succ) {
+                        // We don't want to leave `restriction`.
+                        continue;
+                    }
+                    let slot = &mut shortest_predecessor[succ.to_index()];
+                    if slot.is_some() {
+                        // This vertex was already discovered using a shorter or equivalent path.
+                        continue;
+                    }
+                    *slot = Some(x);
+                    new_frontier.push(*succ);
                 }
-            } else {
-                stack.pop();
-                continue;
             }
+
+            frontier = new_frontier;
         }
 
-        best_cycle
+        None
     }
 
-    /// Same as `shortest_cycle_length`, but in this scenario, only cycles of prescribed `parity`
+    /// Same as `shortest_cycle`, but in this scenario, only cycles of prescribed `parity`
     /// are considered.
     ///
     /// Cycle parity is calculated over the monotonicity of its edges (i.e. `+` and `-` is
@@ -133,28 +87,8 @@ impl SdGraph {
     /// can be always made into positive parity cycle by repeating it twice.
     ///
     /// Finally, you can restrict the search to only include cycles of a specific length
-    /// by providing the `upper_bound`.
-    pub fn shortest_parity_cycle_length(
-        &self,
-        restriction: &HashSet<VariableId>,
-        pivot: VariableId,
-        target_parity: Sign,
-        upper_bound: usize,
-    ) -> Option<usize> {
-        // For generic length, it makes sense to compute using BFS, but for parity length,
-        // its not actually that straightforward. If we really want to ensure only simple cycles
-        // are counted, we have to use the more costly DFS method.
-        self.shortest_parity_cycle(restriction, pivot, target_parity, upper_bound)
-            .map(|it| it.len())
-    }
-
-    /// Same as `shortest_cycle`, but in this scenario, only cycles of prescribed `parity`
-    /// are considered.
-    ///
-    /// See also `shortest_parity_cycle_length` on more discussion about parity.
-    ///
-    /// Finally, you can restrict the search to only include cycles of a specific length
-    /// by providing the `upper_bound`.
+    /// by providing an inclusive `upper_bound` (the length is counted as the number of
+    /// edges in the cycle, i.e. a cycle is returned only if `edge_count <= upper_bound`).
     pub fn shortest_parity_cycle(
         &self,
         restriction: &HashSet<VariableId>,
@@ -162,81 +96,86 @@ impl SdGraph {
         target_parity: Sign,
         upper_bound: usize,
     ) -> Option<Vec<VariableId>> {
-        assert!(restriction.contains(&pivot));
+        assert!(
+            restriction.contains(&pivot),
+            "Pivot vertex must be present in the restriction set."
+        );
 
-        let mut best_cycle: Option<Vec<VariableId>> = None;
-        let mut best_cycle_length = usize::MAX;
-        let mut distances: HashMap<(VariableId, Sign), usize> = restriction
-            .iter()
-            .map(|it| ((*it, Positive), usize::MAX))
-            .chain(restriction.iter().map(|it| ((*it, Negative), usize::MAX)))
-            .collect();
-        distances.insert((pivot, Positive), 0);
-        distances.insert((pivot, Negative), 0);
+        // Shortest_cycle is called so often when computing a feedback vertex set, that this
+        // actually helps with performance quite a bit compared to a normal hash map.
+        let mut shortest_positive_predecessor: Vec<Option<(VariableId, Sign)>> =
+            vec![None; self.successors.len()];
+        let mut shortest_negative_predecessor: Vec<Option<(VariableId, Sign)>> =
+            vec![None; self.successors.len()];
 
-        fn successor_function(
-            graph: &SdGraph,
-            restriction: &HashSet<VariableId>,
-            vertex: VariableId,
-        ) -> Vec<(VariableId, Sign)> {
-            graph.successors[vertex.to_index()]
-                .iter()
-                .cloned()
-                .filter(|(it, _)| restriction.contains(it))
-                .collect()
-        }
-
-        let mut stack = vec![(
-            (pivot, Positive),
-            successor_function(self, restriction, pivot),
-        )];
-
-        while let Some((item, successors)) = stack.last_mut() {
-            let vertex_distance = distances[item];
-
-            if best_cycle_length <= vertex_distance || upper_bound <= vertex_distance {
-                stack.pop();
-                continue;
+        // No need for frontier to be a set, because each vertex is inserted only if it is
+        // inserted into `shortest_*_predecessor` first, where it is only inserted at most once.
+        let mut frontier = vec![(pivot, Positive)];
+        let mut length = 0usize;
+        while !frontier.is_empty() {
+            length += 1;
+            if length > upper_bound {
+                // There may be a cycle, but it has more than `upper_bound` edges.
+                return None;
             }
 
-            if let Some((successor, edge_sign)) = successors.pop() {
-                let path_parity = item.1 + edge_sign;
+            let mut new_frontier = Vec::with_capacity(frontier.len());
+            for (x, x_sign) in frontier {
+                for (succ, succ_sign) in &self.successors[x.to_index()] {
+                    let path_sign = x_sign + *succ_sign;
+                    if *succ == pivot && path_sign == target_parity {
+                        // Found cycle. Because this is BFS, the cycle is minimal,
+                        // we just have to back-track. However, it may not be simple: if it
+                        // contains the same node twice, it is not a valid cycle.
+                        let mut cycle = vec![(x, x_sign)];
+                        let mut cycle_set: HashSet<VariableId> = HashSet::from_iter([x]);
+                        while let Some((last, last_sign)) = cycle.last() {
+                            if *last == pivot {
+                                cycle.reverse();
+                                return Some(Vec::from_iter(cycle.into_iter().map(|(x, _)| x)));
+                            }
+                            let next = if *last_sign == Positive {
+                                shortest_positive_predecessor[last.to_index()].unwrap()
+                            } else {
+                                shortest_negative_predecessor[last.to_index()].unwrap()
+                            };
 
-                let successor_distance = distances[&(successor, path_parity)];
-                let new_successor_distance = min(successor_distance, vertex_distance + 1);
-                if new_successor_distance < successor_distance {
-                    // Note that this can't happen to the pivot since its distance is always zero.
-
-                    // However, we still have to ensure that only simple cycles are explored,
-                    // and for this we have to look at the whole stack.
-                    let is_on_stack = stack.iter().any(|((x, _), _)| *x == successor);
-                    if !is_on_stack {
-                        distances.insert((successor, path_parity), new_successor_distance);
-                        stack.push((
-                            (successor, path_parity),
-                            successor_function(self, restriction, successor),
-                        ));
-                    }
-                } else if successor == pivot {
-                    // Here, we then have to handle pivot independently.
-                    if path_parity == target_parity {
-                        let cycle_on_stack: Vec<VariableId> =
-                            stack.iter().map(|((it, _), _)| *it).collect();
-                        if cycle_on_stack.len() < best_cycle_length {
-                            best_cycle_length = cycle_on_stack.len();
-                            best_cycle = Some(cycle_on_stack);
+                            if cycle_set.contains(&next.0) {
+                                // If duplicity is detected, the cycle is invalid.
+                                break;
+                            } else {
+                                // Otherwise extend the cycle with a new node.
+                                cycle_set.insert(next.0);
+                                cycle.push(next);
+                            }
                         }
                     }
-                } else {
-                    // Otherwise, do nothing. The successor cannot be improved by this path.
+                    if *succ == pivot {
+                        // Eliminates some spurious cycles with node repetition.
+                        continue;
+                    }
+                    if !restriction.contains(succ) {
+                        // We don't want to leave `restriction`.
+                        continue;
+                    }
+                    let slot = if path_sign == Positive {
+                        &mut shortest_positive_predecessor[succ.to_index()]
+                    } else {
+                        &mut shortest_negative_predecessor[succ.to_index()]
+                    };
+                    if slot.is_some() {
+                        // This vertex was already discovered using a shorter or equivalent path.
+                        continue;
+                    }
+                    *slot = Some((x, x_sign));
+                    new_frontier.push((*succ, path_sign));
                 }
-            } else {
-                stack.pop();
-                continue;
             }
+
+            frontier = new_frontier;
         }
 
-        best_cycle
+        None
     }
 }
 
@@ -277,19 +216,6 @@ mod tests {
         let upper_bound = usize::MAX;
 
         assert_eq!(
-            Some(3),
-            graph.shortest_cycle_length(&vertices, x_1, upper_bound)
-        );
-        assert_eq!(
-            Some(4),
-            graph.shortest_cycle_length(&vertices, x_2, upper_bound)
-        );
-        assert_eq!(
-            None,
-            graph.shortest_cycle_length(&vertices, x_6, upper_bound)
-        );
-
-        assert_eq!(
             Some(vec![x_1, x_5, x_4]),
             graph.shortest_cycle(&vertices, x_1, upper_bound)
         );
@@ -301,10 +227,6 @@ mod tests {
 
         vertices.remove(&x_5);
 
-        assert_eq!(
-            Some(4),
-            graph.shortest_cycle_length(&vertices, x_1, upper_bound)
-        );
         assert_eq!(
             Some(vec![x_1, x_2, x_3, x_4]),
             graph.shortest_cycle(&vertices, x_1, upper_bound)
@@ -334,49 +256,12 @@ mod tests {
         let x_3 = rg.find_variable("x_3").unwrap();
         let x_4 = rg.find_variable("x_4").unwrap();
         let x_5 = rg.find_variable("x_5").unwrap();
-        let x_6 = rg.find_variable("x_6").unwrap();
 
         let graph = SdGraph::from(&rg);
 
         let mut vertices = graph.mk_all_vertices();
 
         let upper_bound = usize::MAX;
-
-        assert_eq!(
-            Some(4),
-            graph.shortest_parity_cycle_length(&vertices, x_1, Positive, upper_bound)
-        );
-        assert_eq!(
-            Some(3),
-            graph.shortest_parity_cycle_length(&vertices, x_1, Negative, upper_bound)
-        );
-
-        assert_eq!(
-            None,
-            graph.shortest_parity_cycle_length(&vertices, x_5, Positive, upper_bound)
-        );
-        assert_eq!(
-            Some(3),
-            graph.shortest_parity_cycle_length(&vertices, x_5, Negative, upper_bound)
-        );
-
-        assert_eq!(
-            Some(4),
-            graph.shortest_parity_cycle_length(&vertices, x_2, Positive, upper_bound)
-        );
-        assert_eq!(
-            None,
-            graph.shortest_parity_cycle_length(&vertices, x_2, Negative, upper_bound)
-        );
-
-        assert_eq!(
-            None,
-            graph.shortest_parity_cycle_length(&vertices, x_6, Positive, upper_bound)
-        );
-        assert_eq!(
-            None,
-            graph.shortest_parity_cycle_length(&vertices, x_6, Negative, upper_bound)
-        );
 
         assert_eq!(
             Some(vec![x_1, x_2, x_3, x_4]),
@@ -396,6 +281,54 @@ mod tests {
         assert_eq!(
             None,
             graph.shortest_parity_cycle(&vertices, x_1, Negative, upper_bound)
+        );
+    }
+
+    #[test]
+    pub fn test_simple_parity_cycles() {
+        // This tests whether the implementation correctly ignores non-simple cycles. The graph
+        // has a positive cycle in which a negative cycle is embedded. We want to test that the
+        // smaller inner cycle is never repeated more than once by the larger cycle.
+
+        let rg = RegulatoryGraph::try_from(
+            r#"
+            x_1 -> x_2
+            x_2 -> x_3
+            x_3 -| x_2
+            x_3 -> x_1
+        "#,
+        )
+        .unwrap();
+
+        let x_1 = rg.find_variable("x_1").unwrap();
+        let x_2 = rg.find_variable("x_2").unwrap();
+        let x_3 = rg.find_variable("x_3").unwrap();
+
+        let graph = SdGraph::from(&rg);
+
+        let vertices = graph.mk_all_vertices();
+
+        let upper_bound = usize::MAX;
+
+        // Node x_1 could have a negative cycle by repeating the inner cycle multiple times, but
+        // this is not allowed.
+        assert_eq!(
+            Some(vec![x_1, x_2, x_3]),
+            graph.shortest_parity_cycle(&vertices, x_1, Positive, upper_bound)
+        );
+        assert_eq!(
+            None,
+            graph.shortest_parity_cycle(&vertices, x_1, Negative, upper_bound)
+        );
+
+        // However, the negative cycle is still there and is detected for x_2
+        assert_eq!(
+            Some(vec![x_2, x_3, x_1]),
+            graph.shortest_parity_cycle(&vertices, x_2, Positive, upper_bound)
+        );
+        assert_eq!(
+            Some(vec![x_2, x_3]),
+            graph.shortest_parity_cycle(&vertices, x_2, Negative, upper_bound)
         );
     }
 }

--- a/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
@@ -167,8 +167,6 @@ mod tests {
         let d_3 = rg.find_variable("d_3").unwrap();
         let e = rg.find_variable("e").unwrap();
 
-        println!("{:?}", rg.variable_names());
-
         let graph = SdGraph::from(&rg);
 
         let vertices = graph.mk_all_vertices();

--- a/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
@@ -1,9 +1,63 @@
 use crate::VariableId;
 use crate::_impl_regulatory_graph::signed_directed_graph::{SdGraph, Sign};
-use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 impl SdGraph {
+    /// A utility function that prunes the `candidates` set to a smaller subset that is still
+    /// guaranteed to be a valid FVS with respect to the specified cycle detection function.
+    ///
+    /// This is not the complete FVS approximation algorithm, but it is used multiple times,
+    /// so we abstract it into this helper method.
+    fn _fvs_helper<F: Fn(&HashSet<VariableId>, VariableId) -> Option<Vec<VariableId>>>(
+        &self,
+        subgraph: &mut HashSet<VariableId>,
+        mut candidates: HashSet<VariableId>,
+        compute_cycle: F,
+    ) -> HashSet<VariableId> {
+        let mut result = HashSet::new();
+
+        // The shortest known cycle in the current `subgraph` for the given `pivot`.
+        let mut shortest_cycle_for_pivot: HashMap<VariableId, Vec<VariableId>> = HashMap::new();
+
+        while !candidates.is_empty() {
+            // Ensure determinism.
+            let mut iterable = Vec::from_iter(candidates.clone());
+            iterable.sort();
+
+            let mut best = (VariableId(0), usize::MAX, 0);
+            for vertex in iterable {
+                let cycle = if let Some(known_cycle) = shortest_cycle_for_pivot.get(&vertex) {
+                    known_cycle
+                } else if let Some(computed_cycle) = compute_cycle(subgraph, vertex) {
+                    shortest_cycle_for_pivot
+                        .entry(vertex)
+                        .or_insert(computed_cycle)
+                } else {
+                    subgraph.remove(&vertex);
+                    candidates.remove(&vertex);
+                    continue;
+                };
+
+                let degree = self.approx_degree(vertex, subgraph);
+                if cycle.len() < best.1 || (cycle.len() == best.1 && degree > best.2) {
+                    best = (vertex, cycle.len(), degree);
+                }
+                if cycle.len() == 1 {
+                    // Self-loops are always optimal.
+                    break;
+                }
+            }
+
+            result.insert(best.0);
+            subgraph.remove(&best.0);
+            candidates.remove(&best.0);
+
+            shortest_cycle_for_pivot.retain(|_k, v| !v.contains(&best.0));
+        }
+
+        result
+    }
+
     /// Compute a feedback vertex set of the subgraph induced by the vertices in the
     /// given `restriction` set.
     ///
@@ -12,8 +66,7 @@ impl SdGraph {
     ///
     /// The algorithm attempts to minimize the size of the resulting FVS, but it
     /// is not guaranteed that the result is minimal, as the minimal FVS problem
-    /// is NP complete. Also note that while the *size* of the result is deterministic,
-    /// the actual vertices may not be as they depend on the iteration order of a `HashSet`.
+    /// is NP complete.
     ///
     /// The algorithm works by greedily picking vertices from the shortest cycles, prioritising
     /// vertices with the highest overall degree.
@@ -21,52 +74,39 @@ impl SdGraph {
         &self,
         restriction: &HashSet<VariableId>,
     ) -> HashSet<VariableId> {
-        let mut result = HashSet::new();
+        let mut candidates = restriction.clone();
 
-        // By preprocessing the state space into components, we avoid a lot of cycle detection
-        // that would otherwise just prove that the variable does not have any cycles.
-        let mut components = self.restricted_strongly_connected_components(restriction);
-        while let Some(mut scc) = components.pop() {
-            let mut best_candidate = (VariableId::from_index(0), usize::MAX, 0usize);
-            // Not particularly efficient but keeps the procedure deterministic.
-            // However, by a lucky coincidence, it also seems to on average improve the results :O
-            let mut scc_iter: Vec<VariableId> = scc.iter().cloned().collect();
-            scc_iter.sort();
-            for x in &scc_iter {
-                if let Some(cycle_length) = self.shortest_cycle_length(&scc, *x, best_candidate.1) {
-                    if cycle_length == 1 {
-                        // If the cycle has length one, it is guaranteed to appear in the FVS
-                        // and we can just stop looking for the other cycles.
-                        best_candidate = (*x, cycle_length, 0);
-                        break;
-                    }
-                    let degree = self.approx_degree(*x, &scc);
-                    match cycle_length.cmp(&best_candidate.1) {
-                        Ordering::Less => {
-                            // If this is the best cycle, just update it.
-                            best_candidate = (*x, cycle_length, degree);
-                        }
-                        Ordering::Equal => {
-                            // If this is equal to the best cycle, compare degrees.
-                            if degree > best_candidate.2 {
-                                best_candidate = (*x, cycle_length, degree);
-                            }
-                        }
-                        _ => (),
-                    }
+        // Preprocessing to remove all nodes with less than two outgoing edges that don't have
+        // a self-loop. (These are either outputs: useless; or are equivalent to the node on the
+        // other end of the single edge. The only exception are self-loop outputs, since these
+        // actually need to be in the FVS)
+        for x in restriction {
+            let mut target_count = 0;
+            let mut has_self_loop = false;
+            for (succ, _) in &self.successors[x.to_index()] {
+                if succ == x {
+                    has_self_loop = true;
+                }
+                if restriction.contains(succ) {
+                    target_count += 1;
                 }
             }
-
-            assert_ne!(best_candidate.1, usize::MAX);
-            result.insert(best_candidate.0);
-            scc.remove(&best_candidate.0);
-
-            // Finally, run SCC decomposition again on the smaller component and "return" results
-            // back into processing.
-            components.append(&mut self.restricted_strongly_connected_components(&scc));
+            if !has_self_loop && target_count <= 1 {
+                candidates.remove(x);
+            }
         }
 
-        result
+        // We then prune the candidates twice: First time, most of the uninteresting nodes are
+        // removed, second time then optimizes the result such that it is (usually) at least
+        // subset minimal. The minimality is still not guaranteed though.
+
+        let candidates = self._fvs_helper(&mut restriction.clone(), candidates, |g, x| {
+            self.shortest_cycle(g, x, usize::MAX)
+        });
+
+        self._fvs_helper(&mut restriction.clone(), candidates, |g, x| {
+            self.shortest_cycle(g, x, usize::MAX)
+        })
     }
 
     /// Compute a feedback vertex set of the desired parity, considered within the subgraph induced
@@ -80,53 +120,15 @@ impl SdGraph {
         restriction: &HashSet<VariableId>,
         parity: Sign,
     ) -> HashSet<VariableId> {
-        let mut result = HashSet::new();
+        // We will be searching in a subset of a known FVS. This is because FVS detection is
+        // a bit faster and usually gives us a reasonable starting point.
+        let candidates = self.restricted_feedback_vertex_set(restriction);
 
-        let mut components = self.restricted_strongly_connected_components(restriction);
-        while let Some(mut scc) = components.pop() {
-            let mut best_candidate = (VariableId::from_index(0), usize::MAX, 0usize);
-            // Not particularly efficient but keeps the procedure deterministic.
-            // However, by a lucky coincidence, it also seems to on average improve the results :O
-            let mut scc_iter: Vec<VariableId> = scc.iter().cloned().collect();
-            scc_iter.sort();
-            for x in &scc_iter {
-                if let Some(cycle_length) =
-                    self.shortest_parity_cycle_length(&scc, *x, parity, best_candidate.1)
-                {
-                    if cycle_length == 1 {
-                        // If the cycle has length one, it is guaranteed to appear in the FVS
-                        // and we can just stop looking for any other cycles.
-                        best_candidate = (*x, cycle_length, 0);
-                        break;
-                    }
-                    let degree = self.approx_degree(*x, &scc);
-                    match cycle_length.cmp(&best_candidate.1) {
-                        Ordering::Less => {
-                            // If this is the best cycle, just update it.
-                            best_candidate = (*x, cycle_length, degree);
-                        }
-                        Ordering::Equal => {
-                            // If this is equal to the best cycle, compare degrees.
-                            if degree > best_candidate.2 {
-                                best_candidate = (*x, cycle_length, degree);
-                            }
-                        }
-                        _ => (),
-                    }
-                }
-            }
-
-            if best_candidate.1 == usize::MAX {
-                // No cycles found.
-                continue;
-            }
-
-            result.insert(best_candidate.0);
-            scc.remove(&best_candidate.0);
-            components.append(&mut self.restricted_strongly_connected_components(&scc));
-        }
-
-        result
+        // The same as normal FVS method, but uses different cycle detection. Here, we don't
+        // repeat it again, because in most cases it is not needed.
+        self._fvs_helper(&mut restriction.clone(), candidates, |g, x| {
+            self.shortest_parity_cycle(g, x, parity, usize::MAX)
+        })
     }
 
     /// **(internal)** Compute the degree of a vertex within the given set.
@@ -156,7 +158,7 @@ mod tests {
 
     #[test]
     pub fn test_feedback_vertex_set() {
-        // Its a similar test graph to the one used for component computation,
+        // It's a similar test graph to the one used for component computation,
         // but `b_1 -> b_2` is a negative cycle and the `d`-component has both one positive and
         // one negative cycle. Finally, `e` has a positive self-loop
         let rg = RegulatoryGraph::try_from(
@@ -184,6 +186,8 @@ mod tests {
         let d_2 = rg.find_variable("d_2").unwrap();
         let d_3 = rg.find_variable("d_3").unwrap();
         let e = rg.find_variable("e").unwrap();
+
+        println!("{:?}", rg.variable_names());
 
         let graph = SdGraph::from(&rg);
 

--- a/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_feedback_vertex_set.rs
@@ -74,27 +74,7 @@ impl SdGraph {
         &self,
         restriction: &HashSet<VariableId>,
     ) -> HashSet<VariableId> {
-        let mut candidates = restriction.clone();
-
-        // Preprocessing to remove all nodes with less than two outgoing edges that don't have
-        // a self-loop. (These are either outputs: useless; or are equivalent to the node on the
-        // other end of the single edge. The only exception are self-loop outputs, since these
-        // actually need to be in the FVS)
-        for x in restriction {
-            let mut target_count = 0;
-            let mut has_self_loop = false;
-            for (succ, _) in &self.successors[x.to_index()] {
-                if succ == x {
-                    has_self_loop = true;
-                }
-                if restriction.contains(succ) {
-                    target_count += 1;
-                }
-            }
-            if !has_self_loop && target_count <= 1 {
-                candidates.remove(x);
-            }
-        }
+        let candidates = restriction.clone();
 
         // We then prune the candidates twice: First time, most of the uninteresting nodes are
         // removed, second time then optimizes the result such that it is (usually) at least

--- a/src/_impl_regulatory_graph/signed_directed_graph/_impl_sd_graph.rs
+++ b/src/_impl_regulatory_graph/signed_directed_graph/_impl_sd_graph.rs
@@ -39,7 +39,7 @@ impl From<&RegulatoryGraph> for SdGraph {
                 }
             }
 
-            // Variables should be well ordered, but just in case...
+            // Variables should be well-ordered, but just in case...
             assert_eq!(var.to_index(), successors.len());
 
             successors.push(next_step);

--- a/src/bin/check_fvs.rs
+++ b/src/bin/check_fvs.rs
@@ -2,19 +2,23 @@
    This is a very simple binary intended as an integration test or benchmark for the FVS
    approximation algorithm. We can run this on the BBM dataset to see if the algorithm is
    responsive and that it produces expected results. It is not included in normal tests
-   because it needs to be compiled with optimizations and generally we don't really want to
+   because it needs to be compiled with optimizations, and generally we don't really want to
    run it every time we test (also, measuring the performance would be harder if this were
    a test).
 */
 
 use biodivine_lib_param_bn::{BooleanNetwork, SdGraph};
+use std::time::Instant;
 
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let model = BooleanNetwork::try_from_file(args[1].as_str()).unwrap();
+    let model = model.infer_valid_graph().unwrap();
 
     // First, compute the feedback vertex set.
+    let start = Instant::now();
     let fvs = model.as_graph().feedback_vertex_set();
+    let elapsed = Instant::now() - start;
     println!("FVS size: {}", fvs.len());
 
     // Then compute the SCC decomposition without the FVS. The result should be empty
@@ -27,4 +31,5 @@ fn main() {
     assert!(graph
         .restricted_strongly_connected_components(&restriction)
         .is_empty());
+    println!("{}, {}", fvs.len(), elapsed.as_millis());
 }

--- a/src/bin/check_nfvs.rs
+++ b/src/bin/check_nfvs.rs
@@ -26,9 +26,8 @@ fn main() {
     // Finally, for every variable, we check that there are indeed no negative cycles.
     for x in model.variables() {
         if restriction.contains(&x) {
-            assert!(graph
-                .shortest_parity_cycle(&restriction, x, Negative, usize::MAX)
-                .is_none());
+            let cycle = graph.shortest_parity_cycle(&restriction, x, Negative, usize::MAX);
+            assert!(cycle.is_none(), "Parity cycle {:?} found for {}.", cycle, x);
         }
     }
     println!("{}, {}", n_fvs.len(), elapsed.as_millis());

--- a/src/bin/check_nfvs.rs
+++ b/src/bin/check_nfvs.rs
@@ -4,13 +4,17 @@
 
 use biodivine_lib_param_bn::Sign::Negative;
 use biodivine_lib_param_bn::{BooleanNetwork, SdGraph};
+use std::time::Instant;
 
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let model = BooleanNetwork::try_from_file(args[1].as_str()).unwrap();
+    let model = model.infer_valid_graph().unwrap();
 
     // First, compute the feedback vertex set.
+    let start = Instant::now();
     let n_fvs = model.as_graph().parity_feedback_vertex_set(Negative);
+    let elapsed = Instant::now() - start;
     println!("nFVS size: {}", n_fvs.len());
 
     let graph = SdGraph::from(model.as_graph());
@@ -27,4 +31,5 @@ fn main() {
                 .is_none());
         }
     }
+    println!("{}, {}", n_fvs.len(), elapsed.as_millis());
 }


### PR DESCRIPTION
This PR represents a complete rework of the cycle detection and FVS computation mechanism.

First of all, it greatly speeds up basic cycle detection and FVS computation. It also simplifies parity FVS computation. However, it uses a completely new algorithm for parity cycle detection. As it turns out, the previous algorithm failed with various edge cases on sufficiently complex graphs. Unfortunately, the new algorithm is slower, because it turns out the overall problem is actually more complicated.

Overall, the impact on FVS detection is still positive, and the detected subsets are also on average smaller than the previous results.

[fvs_comparison.xlsx](https://github.com/sybila/biodivine-lib-param-bn/files/14197005/fvs_comparison.xlsx)