### PR TITLE
ChatGPT: Implements support for booleannet network format

### DIFF
--- a/booleannet_models/ABA.txt
+++ b/booleannet_models/ABA.txt
@@ -1,0 +1,68 @@
+
+# lines starting with the # symbol are comments
+
+
+#
+# Abscisic Acid signaling model
+#
+# Node initialization below, 
+# ( all other nodes are set to random values in the program)
+#
+
+Closure = False
+ABA = ABH1 = ERA1 = AGB1 = True
+
+
+#
+# Model specification syntax
+#
+# rank: node1 *=  node1 and node2 or node3  ... etc
+#
+# The first number is the rank (all are set to 1 here)
+#
+# 1: A *= A or B
+#
+# means that the new value of A is equal to the old values 
+# of A and B combined with the operator 'or'
+#
+# model starts below
+#
+
+1: SphK* = ABA
+1: S1P* =  SphK
+1: GPA1* = (S1P or not GCR1) and AGB1
+1: PLD* = GPA1
+1: PA * = PLD
+1: pHc * = ABA
+1: OST1* = ABA
+1: ROP2* = PA
+1: Atrboh* = pHc and OST1 and ROP2 and not ABI1
+1: ROS* = Atrboh
+1: H+ATPase* = not ROS and not pHc and not Ca2+c
+1: ABI1* = pHc and not PA and not ROS
+1: RCN1*= ABA
+1: NIA12*= RCN1
+1: NOS* = Ca2+c
+1: NO* = NIA12 and NOS
+1: GC* = NO
+1: ADPRc* =  NO
+1: cADPR* = ADPRc
+1: cGMP* = GC
+1: PLC* = ABA and Ca2+c
+1: InsP3* = PLC
+1: InsPK* = ABA
+1: InsP6* = InsPK
+1: CIS* = (cGMP and cADPR) or (InsP3 and InsP6) 
+1: Ca2+ATPase* = Ca2+c
+1: Ca2+c * = (CaIM or CIS) and (not Ca2+ATPase)
+1: AnionEM* = ((Ca2+c or pHc) and not ABI1 ) or (Ca2+c and pHc)
+1: Depolar* = KEV or AnionEM  or (not H+ATPase) or (not KOUT) or Ca2+c
+1: CaIM* = (ROS or not ERA1 or not ABH1) and (not Depolar)
+1: KOUT* = (pHc or not ROS or not NO) and Depolar
+1: KAP* = (not pHc or not Ca2+c) and Depolar
+1: KEV* = Ca2+c
+1: PEPC* = not ABA
+1: Malate* = PEPC and not ABA and not AnionEM
+1: RAC1* = not ABA and not ABI1
+1: Actin* = Ca2+c  or not RAC1
+1: Closure* = (KOUT or KAP ) and AnionEM  and Actin and not Malate

--- a/booleannet_models/Bb.txt
+++ b/booleannet_models/Bb.txt
@@ -1,0 +1,62 @@
+
+# lines starting with the # symbol are comments
+
+#
+# Mammalian immune response to B. bronchiseptica infection
+#
+# Node initialization is done programattically from excel files
+# saved in csv format. See code for details
+#
+# Model specification syntax
+#
+# rank: node1 *=  node1 and node2 or node3  ... etc
+#
+# The first number is the rank (all are set to 1 here)
+#
+# 1: A *= A or B
+#
+# means that the new value of A is equal to the old values 
+# of A and B combined with the operator 'or'
+#
+# Note that in this simulation most nodes are altered at runtime
+#
+#
+#I:  I/ Lungs
+#II: compartment II/ Lymph
+#
+# model starts below
+
+1: Bb* = Bb and not PH 
+1: TTSSI* = Bb and not (Cab or Oab) 
+1: TTSSII* = TTSSI
+1: Oag* = Bb
+1: EC* = Bb
+1: Cab* = BC or Cab
+1: C* = (Bb and not Oag) or (AgAb and Cab) 
+1: AgAb* = Bb and (Oab or Cab)
+1: Oab* = BC or Oab
+1: BC* = Th2II
+1: PIC* = (EC or DP or AP) and not IL10I
+1: IL12I* = (DCII and T0 and not IL4II) #1-prop
+1: IL12II* = (DCII and T0 and not IL4II)#prop
+1: IL4I* = (DCII and T0) and not IL12II #1-prop
+1: IL4II* = (DCII and T0) and not IL12II #prop
+1: IL10I* = (TrI or Th2I or (MPI and TTSSI)) and not IL12I 
+1: IL10II* = (TrI or Th2I or (MPI and TTSSI)) and not IL12I 
+1: IFNgI* = (Th1I or MPI) and not (IL10I or IL4I) #prop
+1: IFNgII* = (Th1I or MPI) and not (IL10I or IL4I) #1-prop
+1: RP* = PIC
+1: DP* = RP and TTSSI
+1: MPI* = (PIC or IFNgI) and not IL10I #lpde(MP)-Hill(MP, H, n)
+1: MPII* = MPI
+1: AP* = Bb and (RP or MPI) and ((C and Cab) or AgAb)
+1: T0* = DCII
+1: TrII* = DCII and T0 and TTSSII
+1: TrI* = TrII
+1: Th1II* = DCII and T0 and IL12II
+1: Th1I* = Th1II
+1: Th2II* = DCII and T0 and not IL12II
+1: Th2I* = Th2II
+1: DCI* = IFNgI or PIC or Bb
+1: DCII* = DCI
+1: PH* = AP and Bb

--- a/booleannet_models/LGL.txt
+++ b/booleannet_models/LGL.txt
@@ -1,0 +1,76 @@
+
+# lines starting with the # symbol are comments
+
+
+#
+# T-cell large granular lymphocyte leukemia model
+#
+# Node initialization below, 
+# ( all other nodes are set to false inside the program)
+#
+
+Stimuli = IAP = Mcl1 = BclxL = PIAS = True
+
+#
+# Model specification syntax
+#
+# rank: new-node1 *=  node1 and node2 or node3  ... etc
+#
+# the first number is the rank (all are set to 1 here)
+#
+# 1: A *= A or B
+#
+# means that the new value of A is equal to the old values 
+# of A and B combined with the operator 'or'
+#
+# model starts below
+#
+1: TCR *= Stimuli and not (CTLA4 or Apoptosis)
+1: Fyn *= IL2RL and not Apoptosis
+1: Migration *= Fyn and not Apoptosis
+1: CTLA4 *= TCR and not Apoptosis
+1: LCK *= (TCR or IL2RL or CD45) and not (CSK or Apoptosis)
+1: PLC *= GRB2 and not Apoptosis
+1: GRB2 *= LCK and not Apoptosis
+1: CSK *= TCR and not Apoptosis
+1: Ceramide *= (BID and FasL) and not Apoptosis
+1: STAT3 *= JAK and not Apoptosis
+1: TBET *= IFNT and not Apoptosis
+1: PIAS *= not (STAT3 or Apoptosis)
+1: C-Myc *= STAT3 and not (Apoptosis or SMAD)
+1: NFAT *= PLC and not Apoptosis 
+1: Proliferation *= C-Myc and not Apoptosis
+1: SMAD *= (TGF and not SMAD7) and not Apoptosis
+1: SMAD7 *= SMAD and not Apoptosis
+1: Flip *= (NFKB or (CREB and IFN)) and not (Ceramide or IL2 or Apoptosis)
+1: NFKB *= ((TPL2 or PI3K) or (Flip and TRADD and IAP)) and not (Apoptosis or PIAS)
+1: IFN *= ((IL2 or Stimuli) and IFNT) and not (Apoptosis or SMAD)
+1: IFNT *= JAK and not Apoptosis
+1: IL2R *= (IL2 and STAT3) and not (IL2R or Apoptosis)
+1: IL2RL *= (IL2 and Erk) and not Apoptosis
+1: TPL2 *= TNF and not Apoptosis
+1: IL2 *= (NFKB or C-Myc or NFAT) and not (SMAD or TBET or Apoptosis)
+1: Ras *= (GRB2 or PLC) and not (GAP or Apoptosis)
+1: FasL *= (C-Myc or NFKB or NFAT or Erk) and not Apoptosis
+1: FasT *= NFKB or FasT and not Apoptosis
+1: Fas *= ((FasT and Ceramide) or (FasT and FasL and not sFas)) and not Apoptosis 
+1: sFas *= sFas
+1: MEK *= (TPL2 or Ras) and not Apoptosis
+1: Caspase *= Fas and not (Flip or IAP or Apoptosis)
+1: TGF *= (SMAD or Erk) and not (TNF or GZMB or Apoptosis)
+1: Erk *= MEK and not (Apoptosis or IFN)
+1: TNF *= (NFKB and PI3K) and not Apoptosis
+1: TRADD *= TNF and not (IAP or Apoptosis)
+1: Apoptosis *= Caspase or Apoptosis
+1: PI3K *= Ras and not Apoptosis
+1: BID *= (Caspase or GZMB) and not (BclxL or Mcl1 or Apoptosis) 
+1: IAP *= NFKB and not Apoptosis
+1: BclxL *= (NFKB and STAT3) and not (BID or (Ras and IFNT) or IL2 or Apoptosis)
+1: SOCS *= JAK and not (Apoptosis or IL2 or IL15)
+1: GAP *= Ras and not (IL15 or IL2 or Apoptosis) 
+1: JAK *= (JAK or IL2RL) and not (SOCS or CD45 or Apoptosis)
+1: RANTES *= NFKB and not Apoptosis
+1: GZMB *= (CREB or TBET or GZMB) and not Apoptosis
+1: CREB *= (Erk and IFN) and not Apoptosis
+1: Stimuli *=Stimuli
+1: Mcl1 *= (STAT3 and NFKB and Erk) and not ((Fas and IL2) or Apoptosis)

--- a/booleannet_models/demo-rules.txt
+++ b/booleannet_models/demo-rules.txt
@@ -1,0 +1,22 @@
+#
+# Test rules 
+#
+#
+# lines starting with # are comments and are ignored, same with empty lines
+#
+
+
+# setting nodes to true and false
+A = B = True
+C = D = False
+
+# randomly chooses True or False, E and F have the same value
+E = F = Random
+
+# another random value for G
+G = Random
+
+# make this one cycle
+1: A* = ( not A )
+1: E *= G and B 
+

--- a/src/_impl_boolean_network_from_booleannet.rs
+++ b/src/_impl_boolean_network_from_booleannet.rs
@@ -1,0 +1,466 @@
+use crate::_aeon_parser::FnUpdateTemp;
+use crate::{BooleanNetwork, RegulatoryGraph, VariableId};
+use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
+
+impl BooleanNetwork {
+    /// Try to load a Boolean network from a `booleannet` model.
+    pub fn try_from_booleannet(model_string: &str) -> Result<BooleanNetwork, String> {
+        let mut name_map = NameMap::new();
+        let mut rules = Vec::new();
+        let mut declared_targets = HashSet::new();
+
+        for (index, raw_line) in model_string.lines().enumerate() {
+            let line_number = index + 1;
+            let line = strip_comment(raw_line);
+            if line.is_empty() {
+                continue;
+            }
+
+            if let Some(rule) = ParsedRule::parse(line, line_number, &mut name_map)? {
+                if !declared_targets.insert(rule.original_target.clone()) {
+                    return Err(format!(
+                        "Duplicate function declaration for `{}` on line {}.",
+                        rule.original_target, line_number
+                    ));
+                }
+                rules.push(rule);
+            } else if line.contains('=') {
+                register_initialization(line, line_number, &mut name_map)?;
+            } else {
+                return Err(format!("Unexpected line {}: `{}`", line_number, line));
+            }
+        }
+
+        if name_map.is_empty() {
+            return Err("Booleannet model does not contain any variables.".to_string());
+        }
+
+        let sanitized_names = name_map.sanitized_names();
+        let mut graph = RegulatoryGraph::new(sanitized_names);
+
+        for rule in &rules {
+            let mut regulators = HashSet::new();
+            rule.template.dump_variables(&mut regulators);
+            let mut regulators = regulators.into_iter().collect::<Vec<_>>();
+            regulators.sort();
+            for regulator in regulators {
+                graph.add_regulation(
+                    regulator.as_str(),
+                    rule.sanitized_target.as_str(),
+                    true,
+                    None,
+                )?;
+            }
+        }
+
+        let mut network = BooleanNetwork::new(graph);
+        for rule in rules {
+            network.add_template_update_function(rule.sanitized_target.as_str(), rule.template)?;
+        }
+
+        name_map.rename_network(&mut network)?;
+
+        Ok(network)
+    }
+}
+
+struct ParsedRule {
+    original_target: String,
+    sanitized_target: String,
+    template: FnUpdateTemp,
+}
+
+impl ParsedRule {
+    fn parse(
+        line: &str,
+        line_number: usize,
+        names: &mut NameMap,
+    ) -> Result<Option<ParsedRule>, String> {
+        if let Some((rank_part, rest)) = line.split_once(':') {
+            Self::parse_ranked_line(rank_part, rest, line_number, names)
+        } else if line.contains('*') && line.contains('=') {
+            Self::parse_simple_line(line, line_number, names)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn parse_ranked_line(
+        rank_part: &str,
+        rest: &str,
+        line_number: usize,
+        names: &mut NameMap,
+    ) -> Result<Option<ParsedRule>, String> {
+        let rank = rank_part.trim();
+        if rank.is_empty() {
+            return Err(format!(
+                "Invalid rule on line {}: missing rank.",
+                line_number
+            ));
+        }
+        rank.parse::<u32>().map_err(|_| {
+            format!(
+                "Invalid rule on line {}: `{}` is not a valid rank.",
+                line_number, rank
+            )
+        })?;
+        Self::parse_target_and_expression(rest.trim(), line_number, names).map(Some)
+    }
+
+    fn parse_simple_line(
+        line: &str,
+        line_number: usize,
+        names: &mut NameMap,
+    ) -> Result<Option<ParsedRule>, String> {
+        Self::parse_target_and_expression(line, line_number, names).map(Some)
+    }
+
+    fn parse_target_and_expression(
+        body: &str,
+        line_number: usize,
+        names: &mut NameMap,
+    ) -> Result<ParsedRule, String> {
+        let star_index = body.find('*').ok_or_else(|| {
+            format!(
+                "Invalid rule on line {}: `{}` does not contain `*`.",
+                line_number, body
+            )
+        })?;
+        let target = body[..star_index].trim();
+        if target.is_empty() {
+            return Err(format!(
+                "Invalid rule on line {}: missing target variable.",
+                line_number
+            ));
+        }
+
+        let remainder = body[star_index + 1..].trim_start();
+        if !remainder.starts_with('=') {
+            return Err(format!(
+                "Invalid rule on line {}: missing `=` after `*`.",
+                line_number
+            ));
+        }
+        let expression = remainder[1..].trim();
+        if expression.is_empty() {
+            return Err(format!(
+                "Invalid rule on line {}: missing right-hand side.",
+                line_number
+            ));
+        }
+
+        let sanitized_target = names.declare(target);
+        let translated = translate_expression(expression, names).map_err(|e| {
+            format!(
+                "Invalid expression for `{}` on line {}: {}",
+                target, line_number, e
+            )
+        })?;
+        let template = FnUpdateTemp::try_from(translated.as_str()).map_err(|e| {
+            format!(
+                "Failed to parse expression for `{}` on line {}: {}",
+                target, line_number, e
+            )
+        })?;
+
+        Ok(ParsedRule {
+            original_target: target.to_string(),
+            sanitized_target,
+            template,
+        })
+    }
+}
+
+struct NameMap {
+    declared_order: Vec<String>,
+    reference_order: Vec<String>,
+    declared_set: HashSet<String>,
+    reference_set: HashSet<String>,
+    original_to_clean: HashMap<String, String>,
+    clean_in_use: HashSet<String>,
+}
+
+impl NameMap {
+    fn new() -> NameMap {
+        NameMap {
+            declared_order: Vec::new(),
+            reference_order: Vec::new(),
+            declared_set: HashSet::new(),
+            reference_set: HashSet::new(),
+            original_to_clean: HashMap::new(),
+            clean_in_use: HashSet::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.declared_order.is_empty() && self.reference_order.is_empty()
+    }
+
+    fn declare(&mut self, original: &str) -> String {
+        let clean = self.ensure_mapping(original);
+        if self.declared_set.insert(original.to_string()) {
+            self.declared_order.push(original.to_string());
+        }
+        clean
+    }
+
+    fn reference(&mut self, original: &str) -> String {
+        let clean = self.ensure_mapping(original);
+        if !self.declared_set.contains(original) && self.reference_set.insert(original.to_string())
+        {
+            self.reference_order.push(original.to_string());
+        }
+        clean
+    }
+
+    fn ensure_mapping(&mut self, original: &str) -> String {
+        if let Some(existing) = self.original_to_clean.get(original) {
+            return existing.clone();
+        }
+
+        let mut base = sanitize_name(original);
+        if base.is_empty() {
+            base.push('_');
+        }
+        if base
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            base = format!("_{}", base);
+        }
+
+        let mut candidate = base.clone();
+        let mut suffix = 1;
+        while self.clean_in_use.contains(&candidate) {
+            suffix += 1;
+            candidate = format!("{}_{}", base, suffix);
+        }
+
+        self.clean_in_use.insert(candidate.clone());
+        self.original_to_clean
+            .insert(original.to_string(), candidate.clone());
+        candidate
+    }
+
+    fn ordered_names(&self) -> Vec<String> {
+        let mut order = self.declared_order.clone();
+        for name in &self.reference_order {
+            if !self.declared_set.contains(name) {
+                order.push(name.clone());
+            }
+        }
+        order
+    }
+
+    fn sanitized_names(&self) -> Vec<String> {
+        self.ordered_names()
+            .iter()
+            .map(|name| self.original_to_clean.get(name).unwrap().clone())
+            .collect()
+    }
+
+    fn rename_network(&self, network: &mut BooleanNetwork) -> Result<(), String> {
+        for (index, original) in self.ordered_names().iter().enumerate() {
+            let id = VariableId(index);
+            if network.get_variable_name(id) == original {
+                continue;
+            }
+            network
+                .as_graph_mut()
+                .set_variable_name(id, original)
+                .map_err(|e| format!("Failed to rename `{}`: {}", original, e))?;
+        }
+        Ok(())
+    }
+}
+
+fn strip_comment(line: &str) -> &str {
+    let without_comment = if let Some(index) = line.find('#') {
+        &line[..index]
+    } else {
+        line
+    };
+    without_comment.trim()
+}
+
+fn register_initialization(
+    line: &str,
+    line_number: usize,
+    names: &mut NameMap,
+) -> Result<(), String> {
+    let tokens: Vec<&str> = line
+        .split('=')
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect();
+    if tokens.len() < 2 {
+        return Err(format!(
+            "Invalid initialization on line {}: `{}`",
+            line_number, line
+        ));
+    }
+
+    let last_is_literal = is_literal(tokens.last().unwrap());
+    let end = if last_is_literal {
+        tokens.len() - 1
+    } else {
+        tokens.len()
+    };
+    if end == 0 {
+        return Err(format!(
+            "Invalid initialization on line {}: `{}`",
+            line_number, line
+        ));
+    }
+
+    for token in &tokens[..end] {
+        names.declare(token);
+    }
+
+    Ok(())
+}
+
+fn is_literal(token: &str) -> bool {
+    matches!(
+        token.to_ascii_lowercase().as_str(),
+        "true" | "false" | "random"
+    )
+}
+
+fn translate_expression(expr: &str, names: &mut NameMap) -> Result<String, String> {
+    let mut result = String::new();
+    let mut needs_space = false;
+    let mut chars = expr.chars().peekable();
+
+    while let Some(ch) = chars.peek().cloned() {
+        if ch.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if ch == '(' {
+            if needs_space {
+                result.push(' ');
+            }
+            result.push('(');
+            chars.next();
+            needs_space = false;
+            continue;
+        }
+        if ch == ')' {
+            result.push(')');
+            chars.next();
+            needs_space = true;
+            continue;
+        }
+
+        let mut token = String::new();
+        while let Some(&inner) = chars.peek() {
+            if inner.is_whitespace() || inner == '(' || inner == ')' {
+                break;
+            }
+            token.push(inner);
+            chars.next();
+        }
+        if token.is_empty() {
+            continue;
+        }
+
+        let lower = token.to_ascii_lowercase();
+        match lower.as_str() {
+            "and" => {
+                result.push_str(" & ");
+                needs_space = false;
+            }
+            "or" => {
+                result.push_str(" | ");
+                needs_space = false;
+            }
+            "not" => {
+                if needs_space {
+                    result.push(' ');
+                }
+                result.push('!');
+                needs_space = false;
+            }
+            "true" => {
+                if needs_space {
+                    result.push(' ');
+                }
+                result.push_str("true");
+                needs_space = true;
+            }
+            "false" => {
+                if needs_space {
+                    result.push(' ');
+                }
+                result.push_str("false");
+                needs_space = true;
+            }
+            "random" => {
+                return Err("`Random` is not supported inside update rules.".to_string());
+            }
+            _ => {
+                let sanitized = names.reference(token.as_str());
+                if needs_space {
+                    result.push(' ');
+                }
+                result.push_str(sanitized.as_str());
+                needs_space = true;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn sanitize_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::BooleanNetwork;
+
+    #[test]
+    fn read_booleannet_demo_model() {
+        let model =
+            std::fs::read_to_string("booleannet_models/demo-rules.txt").expect("demo model");
+        let network = BooleanNetwork::try_from_booleannet(model.as_str()).unwrap();
+
+        assert_eq!(7, network.num_vars());
+        let graph = network.as_graph();
+        let a = graph.find_variable("A").unwrap();
+        let e = graph.find_variable("E").unwrap();
+        let b = graph.find_variable("B").unwrap();
+
+        assert!(network.get_update_function(a).is_some());
+        assert!(network.get_update_function(e).is_some());
+        assert!(network.get_update_function(b).is_none());
+    }
+
+    #[test]
+    fn read_booleannet_aba_model() {
+        let model = std::fs::read_to_string("booleannet_models/ABA.txt").expect("ABA model");
+        let network = BooleanNetwork::try_from_booleannet(model.as_str()).unwrap();
+
+        let graph = network.as_graph();
+        let closure = graph.find_variable("Closure").unwrap();
+        let calcium = graph.find_variable("Ca2+c").unwrap();
+        let pump = graph.find_variable("H+ATPase").unwrap();
+
+        assert!(network.get_update_function(closure).is_some());
+        assert!(network.get_update_function(calcium).is_some());
+        assert!(network.get_update_function(pump).is_some());
+    }
+}

--- a/src/_impl_boolean_network_to_booleannet.rs
+++ b/src/_impl_boolean_network_to_booleannet.rs
@@ -1,0 +1,118 @@
+use crate::{BinaryOp, BooleanNetwork, FnUpdate};
+
+impl BooleanNetwork {
+    /// Produce a `booleannet` string representation of this model.
+    pub fn to_booleannet(&self) -> Result<String, String> {
+        let mut result = String::from("# booleannet export\n");
+        for var in self.variables() {
+            if let Some(function) = self.get_update_function(var) {
+                let rule = fn_update_to_booleannet_string(function, self)?;
+                result.push_str(&format!("1: {}* = {}\n", self.get_variable_name(var), rule));
+            } else if !self.regulators(var).is_empty() {
+                return Err(format!(
+                    "Variable `{}` has no update function. Parametrised networks \
+cannot be exported to booleannet.",
+                    self.get_variable_name(var)
+                ));
+            }
+        }
+        Ok(result)
+    }
+}
+
+fn fn_update_to_booleannet_string(
+    function: &FnUpdate,
+    network: &BooleanNetwork,
+) -> Result<String, String> {
+    Ok(match function {
+        FnUpdate::Var(id) => network.get_variable_name(*id).clone(),
+        FnUpdate::Const(value) => {
+            if *value {
+                "True".to_string()
+            } else {
+                "False".to_string()
+            }
+        }
+        FnUpdate::Param(id, args) => {
+            if args.is_empty() {
+                network.get_parameter(*id).get_name().to_string()
+            } else {
+                return Err(
+                    "Networks with free (parameterised) functions cannot be exported to booleannet."
+                        .to_string(),
+                );
+            }
+        }
+        FnUpdate::Not(inner) => {
+            format!("(not {})", fn_update_to_booleannet_string(inner, network)?)
+        }
+        FnUpdate::Binary(op, left, right) => {
+            let left = fn_update_to_booleannet_string(left, network)?;
+            let right = fn_update_to_booleannet_string(right, network)?;
+            match *op {
+                BinaryOp::And => format!("({} and {})", left, right),
+                BinaryOp::Or => format!("({} or {})", left, right),
+                BinaryOp::Imp => format!("((not {}) or {})", left, right),
+                BinaryOp::Iff => format!(
+                    "((({} and {}) or ((not {}) and (not {}))))",
+                    left, right, left, right
+                ),
+                BinaryOp::Xor => format!(
+                    "((({} and (not {})) or ((not {}) and {})))",
+                    left, right, left, right
+                ),
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::BooleanNetwork;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn booleannet_round_trip() {
+        let model = std::fs::read_to_string("aeon_models/g2a_instantiated.aeon").unwrap();
+        let network = BooleanNetwork::try_from(model.as_str()).unwrap();
+
+        let exported = network.to_booleannet().unwrap();
+        let network_after =
+            BooleanNetwork::try_from_booleannet(exported.as_str()).expect("round trip");
+
+        assert_eq!(network.graph.num_vars(), network_after.graph.num_vars());
+        for v in network.graph.variables() {
+            assert_eq!(
+                network.graph.get_variable(v),
+                network_after.graph.get_variable(v)
+            );
+            let source_regs = network.graph.regulators(v);
+            let roundtrip_regs = network_after.graph.regulators(v);
+            if source_regs != roundtrip_regs {
+                let var_name = network.graph.get_variable_name(v);
+                let before: Vec<String> = source_regs
+                    .iter()
+                    .map(|id| network.graph.get_variable_name(*id).clone())
+                    .collect();
+                let after: Vec<String> = roundtrip_regs
+                    .iter()
+                    .map(|id| network_after.graph.get_variable_name(*id).clone())
+                    .collect();
+                panic!(
+                    "Regulators differ for `{}`. Expected {:?} but found {:?}.",
+                    var_name, before, after
+                );
+            }
+            assert_eq!(
+                network.get_update_function(v),
+                network_after.get_update_function(v)
+            );
+        }
+    }
+
+    #[test]
+    fn booleannet_export_invalid() {
+        let bn = BooleanNetwork::try_from("A -> B \n B -> A").unwrap();
+        assert!(bn.to_booleannet().is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,12 @@ mod _impl_boolean_network;
 mod _impl_boolean_network_display;
 /// **(internal)** Implements experimental `.bnet` parser for `BooleanNetwork`.
 mod _impl_boolean_network_from_bnet;
+/// **(internal)** Implements experimental `booleannet` parser for `BooleanNetwork`.
+mod _impl_boolean_network_from_booleannet;
 /// **(internal)** Implements an experimental `.bnet` writer for `BooleanNetwork`.
 mod _impl_boolean_network_to_bnet;
+/// **(internal)** Implements experimental `booleannet` writer for `BooleanNetwork`.
+mod _impl_boolean_network_to_booleannet;
 /// **(internal)** All methods implemented by the `ExtendedBoolean` object.
 mod _impl_extended_boolean;
 /// **(internal)** Utility methods for `FnUpdate`.


### PR DESCRIPTION
Original assignment: 

Booleannet is a format for representing Boolean networks used by the `booleannet` Python package. We would like to introduce support for this format into this project.

 - Folder `booleannet_models` contains several examples of how the format looks like. Note that the examples contain comments that explain the format further.
 - Please explore the example and the current project structure to develop a plan for implementing this functionality. Specifically, we want to be able to read and write booleannet files as `BooleanNetwork` objects.
 - In your plan, make sure to first develop tests for every new feature and only then implement it.

Once you have a plan, please execute it and implement the new functionality. Make sure all the tests pass and there are no clippy issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete support for Booleannet model file format, enabling loading and exporting of Boolean network models
  * Introduced four new sample biological network models: an Abscisic Acid plant hormone signaling network, a B. bronchiseptica bacterial immune response network, a T-cell large granular lymphocyte leukemia signaling network, and an interactive demonstration model

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->